### PR TITLE
MAINT: Add static type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,8 +95,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        check: ['spellcheck']
-
+        check: ['spellcheck', 'typecheck']
     steps:
       - uses: actions/checkout@v4
       - name: Install the latest version of uv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,20 +154,20 @@ htmlhelp_basename = "nifreezedoc"
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-}
+# latex_elements = {
+#     # The paper size ('letterpaper' or 'a4paper').
+#     #
+#     # 'papersize': 'letterpaper',
+#     # The font size ('10pt', '11pt' or '12pt').
+#     #
+#     # 'pointsize': '10pt',
+#     # Additional stuff for the LaTeX preamble.
+#     #
+#     # 'preamble': '',
+#     # Latex figure (float) alignment
+#     #
+#     # 'figure_align': 'htbp',
+# }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,6 @@ autodoc_mock_imports = [
     "nipype",
     "nitime",
     "nitransforms",
-    "numpy",
     "pandas",
     "scipy",
     "seaborn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,15 @@ test = [
     "pytest-env",
     "pytest-xdist >= 1.28"
 ]
+types = [
+  "pandas-stubs",
+  "types-setuptools",
+  "scipy-stubs",
+  "types-PyYAML",
+  "types-tqdm",
+  "pytest",
+  "microsoft-python-type-stubs @ git+https://github.com/microsoft/python-type-stubs.git",
+]
 
 notebooks = [
     "jupyter",
@@ -137,6 +146,16 @@ version-file = "src/nifreeze/_version.py"
 #
 # Developer tool configurations
 #
+
+[[tool.mypy.overrides]]
+module = [
+  "nipype.*",
+  "nilearn.*",
+  "nireports.*",
+  "nitransforms.*",
+  "seaborn",
+]
+ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,11 @@ module = [
   "nireports.*",
   "nitransforms.*",
   "seaborn",
+  "dipy.*",
+  "smac.*",
+  "joblib",
+  "h5py",
+  "ConfigSpace",
 ]
 ignore_missing_imports = true
 

--- a/scripts/dwi_gp_estimation_error_analysis.py
+++ b/scripts/dwi_gp_estimation_error_analysis.py
@@ -74,7 +74,14 @@ def cross_validate(
     """
 
     rkf = RepeatedKFold(n_splits=cv, n_repeats=n_repeats)
-    scores = cross_val_score(gpr, X, y, scoring="neg_root_mean_squared_error", cv=rkf)
+    # scikit-learn stubs do not recognize rkf as a BaseCrossValidator
+    scores = cross_val_score(
+        gpr,
+        X,
+        y,
+        scoring="neg_root_mean_squared_error",
+        cv=rkf,  # type: ignore[arg-type]
+    )
     return scores
 
 

--- a/scripts/dwi_gp_estimation_error_analysis.py
+++ b/scripts/dwi_gp_estimation_error_analysis.py
@@ -49,7 +49,7 @@ def cross_validate(
     cv: int,
     n_repeats: int,
     gpr: DiffusionGPR,
-) -> dict[int, list[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]]:
+) -> np.ndarray:
     """
     Perform the experiment by estimating the dMRI signal using a Gaussian process model.
 
@@ -211,10 +211,10 @@ def main() -> None:
 
     if args.kfold:
         # Use Scikit-learn cross validation
-        scores = defaultdict(list, {})
+        scores: dict[str, list] = defaultdict(list, {})
         for n in args.kfold:
             for i in range(args.repeats):
-                cv_scores = -1.0 * cross_validate(X, y.T, n, gpr)
+                cv_scores = -1.0 * cross_validate(X, y.T, n, i, gpr)
                 scores["rmse"] += cv_scores.tolist()
                 scores["repeat"] += [i] * len(cv_scores)
                 scores["n_folds"] += [n] * len(cv_scores)
@@ -224,7 +224,7 @@ def main() -> None:
             print(f"Finished {n}-fold cross-validation")
 
         scores_df = pd.DataFrame(scores)
-        scores_df.to_csv(args.output_scores, sep="\t", index=None, na_rep="n/a")
+        scores_df.to_csv(args.output_scores, sep="\t", index=False, na_rep="n/a")
 
         grouped = scores_df.groupby(["n_folds"])
         print(grouped[["rmse"]].mean())

--- a/scripts/dwi_gp_estimation_error_analysis_plot.py
+++ b/scripts/dwi_gp_estimation_error_analysis_plot.py
@@ -100,7 +100,7 @@ def main() -> None:
         bval = bval[0]
     else:
         raise ValueError(f"More than one unique bval value: {bval}")
-    rmse_data = [df.groupby("n_folds").get_group(k)["rmse"].values for k in kfolds]
+    rmse_data = np.asarray([df.groupby("n_folds").get_group(k)["rmse"].values for k in kfolds])
     axis = 1
     mean = np.mean(rmse_data, axis=axis)
     std_dev = np.std(rmse_data, axis=axis)

--- a/scripts/dwi_gp_estimation_error_analysis_plot.py
+++ b/scripts/dwi_gp_estimation_error_analysis_plot.py
@@ -89,9 +89,17 @@ def main() -> None:
     df = pd.read_csv(args.error_data_fname, sep="\t", keep_default_na=False, na_values="n/a")
 
     # Plot the prediction error
-    kfolds = sorted(np.unique(df["n_folds"].values))
-    snr = np.unique(df["snr"].values).item()
-    bval = np.unique(df["bval"].values).item()
+    kfolds = sorted(pd.unique(df["n_folds"]))
+    snr = pd.unique(df["snr"])
+    if len(snr) == 1:
+        snr = snr[0]
+    else:
+        raise ValueError(f"More than one unique SNR value: {snr}")
+    bval = pd.unique(df["bval"])
+    if len(bval) == 1:
+        bval = bval[0]
+    else:
+        raise ValueError(f"More than one unique bval value: {bval}")
     rmse_data = [df.groupby("n_folds").get_group(k)["rmse"].values for k in kfolds]
     axis = 1
     mean = np.mean(rmse_data, axis=axis)

--- a/scripts/dwi_gp_estimation_simulated_signal.py
+++ b/scripts/dwi_gp_estimation_simulated_signal.py
@@ -132,11 +132,11 @@ def main() -> None:
 
     # Fit the Gaussian Process regressor and predict on an arbitrary number of
     # directions
-    a = 1.15
-    lambda_s = 120
+    beta_a = 1.15
+    beta_l = 120
     alpha = 100
     gpr = DiffusionGPR(
-        kernel=SphericalKriging(a=a, lambda_s=lambda_s),
+        kernel=SphericalKriging(beta_a=beta_a, beta_l=beta_l),
         alpha=alpha,
         optimizer=None,
     )

--- a/scripts/dwi_gp_estimation_simulated_signal.py
+++ b/scripts/dwi_gp_estimation_simulated_signal.py
@@ -154,6 +154,8 @@ def main() -> None:
     X_test = np.vstack([gtab[~gtab.b0s_mask].bvecs, sph.vertices])
 
     predictions = gpr_fit.predict(X_test)
+    if isinstance(predictions, tuple):
+        predictions = predictions[0]
 
     # Save the predicted data
     testsims.serialize_dwi(predictions.T, args.dwi_pred_data_fname)

--- a/scripts/optimize_registration.py
+++ b/scripts/optimize_registration.py
@@ -127,12 +127,13 @@ async def train_coro(
             moving_path = tmp_folder / f"test-{index:04d}.nii.gz"
             (~xfm).apply(refnii, reference=refnii).to_filename(moving_path)
 
+            _kwargs = {"output_transform_prefix": f"conversion-{index:04d}", **align_kwargs}
+
             cmdline = erants.generate_command(
                 fixed_path,
                 moving_path,
                 fixedmask_path=brainmask_path,
-                output_transform_prefix=f"conversion-{index:04d}",
-                **align_kwargs,
+                **_kwargs,
             )
 
             tasks.append(

--- a/src/nifreeze/cli/parser.py
+++ b/src/nifreeze/cli/parser.py
@@ -29,13 +29,13 @@ from typing import Optional
 import yaml
 
 
-def _parse_yaml_config(file_path: Path) -> dict:
+def _parse_yaml_config(file_path: str) -> dict:
     """
     Parse YAML configuration file.
 
     Parameters
     ----------
-    file_path : Path
+    file_path : str
         Path to the YAML configuration file.
 
     Returns

--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -36,7 +36,7 @@ import numpy as np
 from nibabel.spatialimages import SpatialHeader, SpatialImage
 from nitransforms.linear import Affine
 
-from ..utils.ndimage import load_api
+from nifreeze.utils.ndimage import load_api
 
 NFDH5_EXT = ".h5"
 
@@ -236,7 +236,7 @@ class BaseDataset(Generic[*Ts]):
                         compression_opts=compression_opts,
                     )
 
-    def to_nifti(self, filename: Path) -> None:
+    def to_nifti(self, filename: Path | str) -> None:
         """
         Write a NIfTI file to disk.
 

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -33,13 +33,15 @@ import attr
 import h5py
 import nibabel as nb
 import numpy as np
+from nibabel.spatialimages import SpatialImage
 from nitransforms.linear import Affine
 
 from nifreeze.data.base import BaseDataset, _cmp, _data_repr
+from nifreeze.utils.ndimage import load_api
 
 
 @attr.s(slots=True)
-class DWI(BaseDataset):
+class DWI(BaseDataset[np.ndarray | None]):
     """Data representation structure for dMRI data."""
 
     bzero = attr.ib(default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp))
@@ -49,6 +51,10 @@ class DWI(BaseDataset):
     eddy_xfms = attr.ib(default=None)
     """List of transforms to correct for estimatted eddy current distortions."""
 
+    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray | None]:
+        return (self.gradients[..., idx] if self.gradients is not None else None,)
+
+    # For the sake of the docstring
     def __getitem__(
         self, idx: int | slice | tuple | np.ndarray
     ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None]:
@@ -74,8 +80,7 @@ class DWI(BaseDataset):
 
         """
 
-        data, affine = super().__getitem__(idx)
-        return data, affine, self.gradients[..., idx]
+        return super().__getitem__(idx)
 
     @classmethod
     def from_filename(cls, filename: Path | str) -> DWI:
@@ -276,7 +281,7 @@ def load(
         return DWI.from_filename(filename)
 
     # 2) Otherwise, load a NIfTI
-    img = nb.load(str(filename))
+    img = load_api(filename, SpatialImage)
     fulldata = img.get_fdata(dtype=np.float32)
     affine = img.affine
 
@@ -319,7 +324,7 @@ def load(
     # 6) b=0 volume (bzero)
     #    If the user provided a b0_file, load it
     if b0_file:
-        b0img = nb.load(str(b0_file))
+        b0img = load_api(b0_file, SpatialImage)
         b0vol = np.asanyarray(b0img.dataobj)
         # We'll assume your DWI class has a bzero: np.ndarray | None attribute
         dwi_obj.bzero = b0vol
@@ -333,7 +338,7 @@ def load(
 
     # 7) If a brainmask_file was provided, load it
     if brainmask_file:
-        mask_img = nb.load(str(brainmask_file))
+        mask_img = load_api(brainmask_file, SpatialImage)
         dwi_obj.brainmask = np.asanyarray(mask_img.dataobj, dtype=bool)
 
     return dwi_obj

--- a/src/nifreeze/data/filtering.py
+++ b/src/nifreeze/data/filtering.py
@@ -77,8 +77,12 @@ def advanced_clip(
     # Calculate stats on denoised version to avoid outlier bias
     denoised = median_filter(data, footprint=ball(3))
 
-    a_min = np.percentile(denoised[denoised >= 0] if nonnegative else denoised, p_min)
-    a_max = np.percentile(denoised[denoised >= 0] if nonnegative else denoised, p_max)
+    a_min = np.percentile(
+        np.asarray([denoised[denoised >= 0] if nonnegative else denoised]), p_min
+    )
+    a_max = np.percentile(
+        np.asarray([denoised[denoised >= 0] if nonnegative else denoised]), p_max
+    )
 
     # Clip and scale data
     data = np.clip(data, a_min=a_min, a_max=a_max)

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 import numpy as np
 from dipy.core.gradients import GradientTable
@@ -138,7 +139,7 @@ class GaussianProcessModel(ReconstModel):
         self,
         data: np.ndarray,
         gtab: GradientTable | np.ndarray,
-        mask: np.ndarray[bool] | None = None,
+        mask: np.ndarray[bool, Any] | None = None,
         random_state: int = 0,
     ) -> GPFit:
         """Fit method of the DTI model class

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -79,7 +79,9 @@ def gp_prediction(
         raise RuntimeError("Model is not yet fitted.")
 
     # Extract orientations from bvecs, and highly likely, the b-value too.
-    return model.predict(X, return_std=return_std)
+    orientations = model.predict(X, return_std=return_std)
+    assert isinstance(orientations, np.ndarray)
+    return orientations
 
 
 class GaussianProcessModel(ReconstModel):

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -87,6 +87,7 @@ class GaussianProcessModel(ReconstModel):
     __slots__ = (
         "kernel",
         "_modelfit",
+        "sigma_sq",
     )
 
     def __init__(

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -212,7 +212,7 @@ class DiffusionGPR(GaussianProcessRegressor):
     ) -> tuple[float, float]:
         options = {}
         if self.optimizer == "fmin_l_bfgs_b":
-            from sklearn.utils.optimize import _check_optimize_result
+            from sklearn.utils.optimize import _check_optimize_result  # type: ignore
 
             for name in LBFGS_CONFIGURABLE_OPTIONS:
                 if (value := getattr(self, name, None)) is not None:

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 from numbers import Integral, Real
-from typing import Callable, ClassVar, Mapping, Optional, Sequence, Union
+from typing import Callable, ClassVar, Literal, Mapping, Optional, Sequence, Union
 
 import numpy as np
 from scipy import optimize
@@ -171,7 +171,7 @@ class DiffusionGPR(GaussianProcessRegressor):
         kernel: Kernel | None = None,
         *,
         alpha: float = 0.5,
-        optimizer: str | Callable | None = "fmin_l_bfgs_b",
+        optimizer: Literal["fmin_l_bfgs_b"] | Callable | None = "fmin_l_bfgs_b",
         n_restarts_optimizer: int = 0,
         copy_X_train: bool = True,
         normalize_y: bool = True,
@@ -229,7 +229,7 @@ class DiffusionGPR(GaussianProcessRegressor):
                 options=options,
                 args=(self.eval_gradient,),
                 tol=self.tol,
-            )
+            )  # type: ignore[call-overload]
             _check_optimize_result("lbfgs", opt_res)
             return opt_res.x, opt_res.fun
 

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 from numbers import Integral, Real
-from typing import Callable, ClassVar, Mapping, Sequence
+from typing import Callable, ClassVar, Mapping, Optional, Sequence, Union
 
 import numpy as np
 from scipy import optimize
@@ -152,6 +152,8 @@ class DiffusionGPR(GaussianProcessRegressor):
         imaging, NeuroImage 125 (2016) 1063-11078
 
     """
+
+    optimizer: Optional[Union[StrOptions, Callable, None]] = None
 
     _parameter_constraints: ClassVar[dict] = {
         "kernel": [None, Kernel],

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -28,6 +28,7 @@ from numbers import Integral, Real
 from typing import Callable, ClassVar, Literal, Mapping, Optional, Sequence, Union
 
 import numpy as np
+import numpy.typing as npt
 from scipy import optimize
 from scipy.optimize import Bounds
 from sklearn.gaussian_process import GaussianProcessRegressor
@@ -334,7 +335,7 @@ class ExponentialKriging(Kernel):
 
         return self.beta_l * C_theta, K_gradient
 
-    def diag(self, X: np.ndarray) -> np.ndarray:
+    def diag(self, X: npt.ArrayLike) -> np.ndarray:
         """Returns the diagonal of the kernel k(X, X).
 
         The result of this method is identical to np.diag(self(X)); however,
@@ -351,7 +352,7 @@ class ExponentialKriging(Kernel):
         K_diag : :obj:`~numpy.ndarray` of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
-        return self.beta_l * np.ones(X.shape[0])
+        return self.beta_l * np.ones(np.asanyarray(X).shape[0])
 
     def is_stationary(self) -> bool:
         """Returns whether the kernel is stationary."""
@@ -444,7 +445,7 @@ class SphericalKriging(Kernel):
 
         return self.beta_l * C_theta, K_gradient
 
-    def diag(self, X: np.ndarray) -> np.ndarray:
+    def diag(self, X: npt.ArrayLike) -> np.ndarray:
         """Returns the diagonal of the kernel k(X, X).
 
         The result of this method is identical to np.diag(self(X)); however,
@@ -461,7 +462,7 @@ class SphericalKriging(Kernel):
         K_diag : :obj:`~numpy.ndarray` of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
-        return self.beta_l * np.ones(X.shape[0])
+        return self.beta_l * np.ones(np.asanyarray(X).shape[0])
 
     def is_stationary(self) -> bool:
         """Returns whether the kernel is stationary."""

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -29,7 +29,7 @@ from typing import Callable, Mapping, Sequence
 
 import numpy as np
 from scipy import optimize
-from scipy.optimize._minimize import Bounds
+from scipy.optimize import Bounds
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import (
     Hyperparameter,

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 from numbers import Integral, Real
-from typing import Callable, Mapping, Sequence
+from typing import Callable, ClassVar, Mapping, Sequence
 
 import numpy as np
 from scipy import optimize
@@ -153,7 +153,7 @@ class DiffusionGPR(GaussianProcessRegressor):
 
     """
 
-    _parameter_constraints: dict = {
+    _parameter_constraints: ClassVar[dict] = {
         "kernel": [None, Kernel],
         "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
         "optimizer": [StrOptions(SUPPORTED_OPTIMIZERS), callable, None],

--- a/src/nifreeze/registration/ants.py
+++ b/src/nifreeze/registration/ants.py
@@ -412,7 +412,7 @@ def _run_registration(
     i_iter: int,
     vol_idx: int,
     dirname: Path,
-    reg_target_type: str,
+    reg_target_type: str | tuple[str, str],
     align_kwargs: dict,
 ) -> nt.base.BaseTransform:
     """
@@ -440,7 +440,7 @@ def _run_registration(
         DWI frame index.
     dirname : :obj:`Path`
         Directory name where the transformation is saved.
-    reg_target_type : :obj:`str`
+    reg_target_type : :obj:`str` or tuple of :obj:`str`
         Target registration type.
     align_kwargs : :obj:`dict`
         Parameters to configure the image registration process.

--- a/src/nifreeze/registration/ants.py
+++ b/src/nifreeze/registration/ants.py
@@ -213,7 +213,7 @@ def generate_command(
     movingmask_path: str | Path | list[str] | None = None,
     init_affine: str | Path | None = None,
     default: str = "b0-to-b0_level0",
-    **kwargs: dict,
+    **kwargs,
 ) -> str:
     """
     Generate an ANTs' command line.

--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -27,7 +27,7 @@ from itertools import chain, zip_longest
 from typing import Iterator
 
 
-def linear_iterator(size: int = None, **kwargs) -> Iterator[int]:
+def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     """
     Traverse the dataset volumes in ascending order.
 
@@ -53,10 +53,10 @@ def linear_iterator(size: int = None, **kwargs) -> Iterator[int]:
     if size is None:
         raise TypeError("Cannot build iterator without size")
 
-    return range(size)
+    return iter(range(size))
 
 
-def random_iterator(size: int = None, **kwargs) -> Iterator[int]:
+def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     """
     Traverse the dataset volumes randomly.
 
@@ -105,7 +105,7 @@ def random_iterator(size: int = None, **kwargs) -> Iterator[int]:
     return (x for x in index_order)
 
 
-def bvalue_iterator(size: int = None, **kwargs) -> Iterator[int]:
+def bvalue_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     """
     Traverse the volumes in a DWI dataset by growing b-value.
 
@@ -132,7 +132,7 @@ def bvalue_iterator(size: int = None, **kwargs) -> Iterator[int]:
     return (index[1] for index in indexed_bvals)
 
 
-def centralsym_iterator(size: int = None, **kwargs) -> Iterator[int]:
+def centralsym_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     """
     Traverse the dataset starting from the center and alternatingly progressing to the sides.
 

--- a/src/nifreeze/viz/signals.py
+++ b/src/nifreeze/viz/signals.py
@@ -37,7 +37,7 @@ def plot_error(
     ylabel: str,
     title: str,
     color: str = "orange",
-    figsize: tuple[int, int] = (19.2, 10.8),
+    figsize: tuple[float, float] = (19.2, 10.8),
 ) -> plt.Figure:
     """
     Plot the error and standard deviation.

--- a/src/nifreeze/viz/signals.py
+++ b/src/nifreeze/viz/signals.py
@@ -74,7 +74,7 @@ def plot_error(
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     ax.set_xticks(kfolds)
-    ax.set_xticklabels(kfolds)
+    ax.set_xticklabels(map(str, kfolds))
     ax.set_title(title)
     fig.tight_layout()
     return fig

--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -90,6 +90,7 @@ def test_set_transform(random_dataset: BaseDataset):
     assert random_dataset.motion_affines is not None
     np.testing.assert_array_equal(random_dataset.motion_affines[idx], affine)
     # The returned affine from __getitem__ should be the same.
+    assert aff0 is not None
     np.testing.assert_array_equal(aff0, affine)
 
 
@@ -121,7 +122,7 @@ def test_to_nifti(random_dataset: BaseDataset):
         assert nifti_file.is_file()
 
         # Load the saved file with nibabel
-        img = nb.load(nifti_file)
+        img = nb.Nifti1Image.from_filename(nifti_file)
         data = img.get_fdata(dtype=np.float32)
         assert data.shape == (32, 32, 32, 5)
         assert np.allclose(data, random_dataset.dataobj)

--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -53,7 +53,7 @@ def test_len(random_dataset: BaseDataset):
     assert len(random_dataset) == 5  # last dimension is 5 volumes
 
 
-def test_getitem_volume_index(random_dataset: BaseDataset):
+def test_getitem_volume_index(random_dataset: BaseDataset[()]):
     """
     Test that __getitem__ returns the correct (volume, affine) tuple.
 
@@ -71,7 +71,7 @@ def test_getitem_volume_index(random_dataset: BaseDataset):
     assert aff_slice is None
 
 
-def test_set_transform(random_dataset: BaseDataset):
+def test_set_transform(random_dataset: BaseDataset[()]):
     """
     Test that calling set_transform changes the data and motion_affines.
     For simplicity, we'll apply an identity transform and check that motion_affines is updated.

--- a/test/test_gpr.py
+++ b/test/test_gpr.py
@@ -20,16 +20,12 @@
 #
 #     https://www.nipreps.org/community/licensing/
 #
-from collections import namedtuple
 
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
 
 from nifreeze.model import gpr
-
-GradientTablePatch = namedtuple("gtab", ["bvals", "bvecs"])
-
 
 THETAS = np.linspace(0, np.pi / 2, num=50)
 EXPECTED_EXPONENTIAL = [

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,15 @@ extras = doc
 commands =
   make -C docs/ SPHINXOPTS="-W -v" BUILDDIR="$HOME/docs" OUTDIR="${CURBRANCH:-html}" html
 
+[testenv:typecheck]
+description = Run mypy type checking
+labels = check
+deps =
+  mypy
+extras = types
+commands =
+  mypy .
+
 [testenv:spellcheck]
 description = Check spelling
 labels = check


### PR DESCRIPTION
Add static type checking: use `mypy` to ensure that variable and function calls are using the appropriate types.

Configure and run `mypy` checks in CI, including the spell checking.

Documentation:
https://mypy.readthedocs.io/en/stable/index.html