### PR TITLE
DOC: Revision of docstrings in the iterators' module

### DIFF
--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -33,9 +33,11 @@ def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int` or ``None`` (optional)
+    size : :obj:`int` or ``None``, optional
         Number of volumes in the dataset.
-    bvalues : :obj:`list`
+        If ``None``, ``size`` will be inferred from the ``bvalues``
+        keyword argument.
+    bvalues : :obj:`list`, optional (keyword argument)
         List of b-values corresponding to all orientations of a DWI dataset.
         If ``size`` is provided, this argument will be ignored.
         Otherwise, ``size`` will be inferred from the length of ``bvalues``.
@@ -63,20 +65,22 @@ def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     """
     Traverse the dataset volumes randomly.
 
-    If the `seed` key is present in the keyword arguments, initializes the seed
-    of Python's `random` pseudo-random number generator library with the given
-    value. Specifically, if `False`, `None` is used as the seed; it `True`, a
+    If the ``seed`` key is present in the keyword arguments, initializes the seed
+    of Python's ``random`` pseudo-random number generator library with the given
+    value. Specifically, if ``False``, ``None`` is used as the seed; if ``True``, a
     default seed value is used.
 
     Parameters
     ----------
-    size : :obj:`int` or ``None`` (optional)
+    size : :obj:`int` or ``None``, optional
         Number of volumes in the dataset.
-    bvalues : :obj:`list` (optional, keyword argument)
+        If ``None``, ``size`` will be inferred from the ``bvalues``
+        keyword argument.
+    bvalues : :obj:`list`, optional (keyword argument)
         List of b-values corresponding to all orientations of a DWI dataset.
         If ``size`` is provided, this argument will be ignored.
         Otherwise, ``size`` will be inferred from the length of ``bvalues``.
-    seed : :obj:`int` or :obj:`bool` or :obj:`bool` or ``None`` (optional, keyword argument)
+    seed : :obj:`int`, :obj:`bool`, :obj:`str`, or ``None``, optional (keyword argument)
         If :obj:`int` or :obj:`str` or ``None``, initializes the seed of Python's random generator
         with the given value.
         If ``False``, the random generator is passed ``None``.
@@ -124,6 +128,8 @@ def bvalue_iterator(*_, **kwargs) -> Iterator[int]:
     ----------
     bvalues : :obj:`list`
         List of b-values corresponding to all orientations of the dataset.
+        Please note that ``bvalues`` is a keyword argument and MUST be provided
+        to generate the volume sequence.
 
     Yields
     ------
@@ -149,9 +155,11 @@ def centralsym_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int` or ``None`` (optional)
+    size : :obj:`int` or ``None``, optional
         Number of volumes in the dataset.
-    bvalues : :obj:`list` (optional, keyword argument)
+        If ``None``, ``size`` will be inferred from the ``bvalues``
+        keyword argument.
+    bvalues : :obj:`list`, optional (keyword argument)
         List of b-values corresponding to all orientations of the dataset.
         If ``size`` is provided, this argument will be ignored.
         Otherwise, ``size`` will be inferred from the length of ``bvalues``.

--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -107,14 +107,9 @@ def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     return (x for x in index_order)
 
 
-def bvalue_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
+def bvalue_iterator(*_, **kwargs) -> Iterator[int]:
     """
     Traverse the volumes in a DWI dataset by growing b-value.
-
-    Parameters
-    ----------
-    bvalues : :obj:`list`
-        List of b-values corresponding to all orientations of the dataset.
 
     Returns
     -------

--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -33,14 +33,16 @@ def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int` or None, optional
-        Number of volumes in the dataset (for instance, the number of
-        orientations in a DWI). If `None`, the size is inferred from the `bvals`
-        argument in `kwargs`, if present.
+    size : :obj:`int` or ``None`` (optional)
+        Number of volumes in the dataset.
+    bvalues : :obj:`list`
+        List of b-values corresponding to all orientations of a DWI dataset.
+        If ``size`` is provided, this argument will be ignored.
+        Otherwise, ``size`` will be inferred from the length of ``bvalues``.
 
-    Returns
-    -------
-    :obj:`~typing.Iterator`
+    Yields
+    ------
+    :obj:`int`
         The sorted index order.
 
     Examples
@@ -54,7 +56,7 @@ def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     if size is None:
         raise TypeError("Cannot build iterator without size")
 
-    return iter(range(size))
+    return (s for s in range(size))
 
 
 def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
@@ -68,14 +70,21 @@ def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int` or None, optional
-        Number of volumes in the dataset (for instance, the number of
-        orientations in a DWI). If `None`, the size is inferred from the `bvals`
-        argument in `kwargs`, if present.
+    size : :obj:`int` or ``None`` (optional)
+        Number of volumes in the dataset.
+    bvalues : :obj:`list` (optional, keyword argument)
+        List of b-values corresponding to all orientations of a DWI dataset.
+        If ``size`` is provided, this argument will be ignored.
+        Otherwise, ``size`` will be inferred from the length of ``bvalues``.
+    seed : :obj:`int` or :obj:`bool` or :obj:`bool` or ``None`` (optional, keyword argument)
+        If :obj:`int` or :obj:`str` or ``None``, initializes the seed of Python's random generator
+        with the given value.
+        If ``False``, the random generator is passed ``None``.
+        If ``True``, a default seed value is set.
 
-    Returns
-    -------
-    :obj:`~typing.Iterator`
+    Yields
+    ------
+    :obj:`int`
         The sorted index order.
 
     Examples
@@ -111,9 +120,14 @@ def bvalue_iterator(*_, **kwargs) -> Iterator[int]:
     """
     Traverse the volumes in a DWI dataset by growing b-value.
 
-    Returns
-    -------
-    :obj:`~typing.Iterator`
+    Parameters
+    ----------
+    bvalues : :obj:`list`
+        List of b-values corresponding to all orientations of the dataset.
+
+    Yields
+    ------
+    :obj:`int`
         The sorted index order.
 
     Examples
@@ -135,14 +149,16 @@ def centralsym_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int` or None, optional
-        Number of volumes in the dataset (for instance, the number of
-        orientations in a DWI). If `None`, the size is inferred from the `bvals`
-        argument in `kwargs`, if present.
+    size : :obj:`int` or ``None`` (optional)
+        Number of volumes in the dataset.
+    bvalues : :obj:`list` (optional, keyword argument)
+        List of b-values corresponding to all orientations of the dataset.
+        If ``size`` is provided, this argument will be ignored.
+        Otherwise, ``size`` will be inferred from the length of ``bvalues``.
 
-    Returns
-    -------
-    :obj:`~typing.Iterator`
+    Yields
+    ------
+    :obj:`~int`
         The sorted index order.
 
     Examples

--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -43,7 +43,7 @@ def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     Yields
     ------
     :obj:`int`
-        The sorted index order.
+        The next index.
 
     Examples
     --------
@@ -85,7 +85,7 @@ def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     Yields
     ------
     :obj:`int`
-        The sorted index order.
+        The next index.
 
     Examples
     --------
@@ -128,7 +128,7 @@ def bvalue_iterator(*_, **kwargs) -> Iterator[int]:
     Yields
     ------
     :obj:`int`
-        The sorted index order.
+        The next index.
 
     Examples
     --------
@@ -159,7 +159,7 @@ def centralsym_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     Yields
     ------
     :obj:`~int`
-        The sorted index order.
+        The next index.
 
     Examples
     --------

--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -33,9 +33,10 @@ def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int`
-        Number of volumes in the dataset
-        (for instance, the number of orientations in a DWI)
+    size : :obj:`int` or None, optional
+        Number of volumes in the dataset (for instance, the number of
+        orientations in a DWI). If `None`, the size is inferred from the `bvals`
+        argument in `kwargs`, if present.
 
     Returns
     -------
@@ -60,16 +61,17 @@ def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     """
     Traverse the dataset volumes randomly.
 
+    If the `seed` key is present in the keyword arguments, initializes the seed
+    of Python's `random` pseudo-random number generator library with the given
+    value. Specifically, if `False`, `None` is used as the seed; it `True`, a
+    default seed value is used.
+
     Parameters
     ----------
-    size : :obj:`int`
-        Number of volumes in the dataset
-        (for instance, the number of orientations in a DWI)
-    seed : :obj:`int` or :obj:`bool` or :obj:`bool` or ``None``
-        If :obj:`int` or :obj:`str` or ``None``, initializes the seed of Python's random generator
-        with the given value.
-        If ``False``, the random generator is passed ``None``.
-        If ``True``, a default seed value is set.
+    size : :obj:`int` or None, optional
+        Number of volumes in the dataset (for instance, the number of
+        orientations in a DWI). If `None`, the size is inferred from the `bvals`
+        argument in `kwargs`, if present.
 
     Returns
     -------
@@ -138,9 +140,10 @@ def centralsym_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    size : :obj:`int`
-        Number of volumes in the dataset
-        (for instance, the number of orientations in a DWI)
+    size : :obj:`int` or None, optional
+        Number of volumes in the dataset (for instance, the number of
+        orientations in a DWI). If `None`, the size is inferred from the `bvals`
+        argument in `kwargs`, if present.
 
     Returns
     -------


### PR DESCRIPTION
- ENH: Add None to b-vals iterators `size` parameter annotations
- ENH: Make `linear_iterator` return an iterator
- ENH: Remove unused parameter form `bvalue_iterator` prototype