### PR TITLE
ENH: Use keyword arguments when calling  DIPY keyword arg functions

### DIFF
--- a/scripts/dwi_gp_estimation_signal_plot.py
+++ b/scripts/dwi_gp_estimation_signal_plot.py
@@ -114,7 +114,7 @@ def main() -> None:
     y_pred = nib.load(args.dwi_pred_data_fname).get_fdata()
 
     bvals, bvecs = read_bvals_bvecs(str(args.bval_data_fname), str(args.bvec_data_fname))
-    gtab = gradient_table(bvals, bvecs)
+    gtab = gradient_table(bvals, bvecs=bvecs)
 
     # Pick one voxel randomly
     rng = np.random.default_rng(1234)

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -286,5 +286,5 @@ def _rasb2dipy(gradient):
         from dipy.core.gradients import gradient_table
 
         warnings.filterwarnings("ignore", category=UserWarning)
-        retval = gradient_table(gradient[3, :], gradient[:3, :].T)
+        retval = gradient_table(gradient[3, :], bvecs=gradient[:3, :].T)
     return retval

--- a/src/nifreeze/testing/simulations.py
+++ b/src/nifreeze/testing/simulations.py
@@ -178,7 +178,7 @@ def create_single_shell_gradient_table(
 
     # Add a b0 value to the gradient table
     bvals, bvecs = add_b0(bvals, bvecs)
-    return gradient_table(bvals, bvecs)
+    return gradient_table(bvals, bvecs=bvecs)
 
 
 def get_query_vectors(


### PR DESCRIPTION
Pass parameters as keyword arguments when calling DIPY functions and methods that have keyword arguments: DIPY has transitioned to keyword-only arguments for these starting version 1.10.0 (released Dec 12, 2024):
https://docs.dipy.org/1.10.0/api_changes.html#dipy-1-10-0-changes

Fixes:
```
src/nifreeze/testing/simulations.py:181:
 UserWarning: Pass ['bvecs'] as keyword args.
 From version 2.0.0 passing these as positional arguments will result in an error.
      return gradient_table(bvals, bvecs)
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/12457578962/job/34772277392?pr=35#step:12:1015