### PR TITLE
BUG: Fix `SphericalKriging` instantiation parameter names in scripts

### DIFF
--- a/scripts/dwi_gp_estimation_error_analysis.py
+++ b/scripts/dwi_gp_estimation_error_analysis.py
@@ -189,11 +189,11 @@ def main() -> None:
 
     snr_str = args.snr if args.snr is not None else "None"
 
-    a = 1.15
-    lambda_s = 120
+    beta_a = 1.15
+    beta_l = 120
     alpha = 1
     gpr = DiffusionGPR(
-        kernel=SphericalKriging(beta_a=a, beta_l=lambda_s),
+        kernel=SphericalKriging(beta_a=beta_a, beta_l=beta_l),
         alpha=alpha,
         optimizer=None,
         # optimizer="Nelder-Mead",

--- a/scripts/dwi_gp_estimation_simulated_signal.py
+++ b/scripts/dwi_gp_estimation_simulated_signal.py
@@ -132,11 +132,11 @@ def main() -> None:
 
     # Fit the Gaussian Process regressor and predict on an arbitrary number of
     # directions
-    a = 1.15
-    lambda_s = 120
+    beta_a = 1.15
+    beta_l = 120
     alpha = 100
     gpr = DiffusionGPR(
-        kernel=SphericalKriging(a=a, lambda_s=lambda_s),
+        kernel=SphericalKriging(beta_a=beta_a, beta_l=beta_l),
         alpha=alpha,
         optimizer=None,
     )


### PR DESCRIPTION
Fix `SphericalKriging` instantiation parameter names in scripts: they were renamed in
https://github.com/nipreps/eddymotion/pull/244/commits/9e65c34f803cc158e036ddd7f0dfd39eb5059cff