### PR TITLE
STYLE: Use the same alias consistently to import `nibabel`

### DIFF
--- a/docs/notebooks/dwi_gp_estimation.ipynb
+++ b/docs/notebooks/dwi_gp_estimation.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "import dipy.data as dpd\n",
-    "import nibabel as nib\n",
+    "import nibabel as nb\n",
     "import numpy as np\n",
     "from dipy.core.gradients import get_bval_indices\n",
     "from dipy.io import read_bvals_bvecs\n",
@@ -35,7 +35,7 @@
     "name = \"sherbrooke_3shell\"\n",
     "\n",
     "dwi_fname, bval_fname, bvec_fname = dpd.get_fnames(name=name)\n",
-    "dwi_data = nib.load(dwi_fname).get_fdata()\n",
+    "dwi_data = nb.load(dwi_fname).get_fdata()\n",
     "bvals, bvecs = read_bvals_bvecs(bval_fname, bvec_fname)\n",
     "\n",
     "_, brain_mask = median_otsu(dwi_data, vol_idx=[0])\n",
@@ -119,7 +119,7 @@
    "source": [
     "from nireports.reportlets.modality.dwi import plot_dwi\n",
     "\n",
-    "affine = nib.load(dwi_fname).affine\n",
+    "affine = nb.load(dwi_fname).affine\n",
     "plot_dwi(\n",
     "    shell_data[..., dwi_vol_idx],\n",
     "    affine,\n",

--- a/scripts/dwi_gp_estimation_signal_plot.py
+++ b/scripts/dwi_gp_estimation_signal_plot.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import nibabel as nib
+import nibabel as nb
 import numpy as np
 from dipy.core.gradients import gradient_table
 from dipy.io import read_bvals_bvecs
@@ -111,8 +111,8 @@ def main() -> None:
     # Plot the predicted DWI signal at a single voxel
 
     # Load the dMRI data
-    signal = load_api(args.dwi_gt_data_fname, nib.Nifti1Image).get_fdata()
-    y_pred = load_api(args.dwi_pred_data_fname, nib.Nifti1Image).get_fdata()
+    signal = load_api(args.dwi_gt_data_fname, nb.Nifti1Image).get_fdata()
+    y_pred = load_api(args.dwi_pred_data_fname, nb.Nifti1Image).get_fdata()
 
     bvals, bvecs = read_bvals_bvecs(str(args.bval_data_fname), str(args.bvec_data_fname))
     gtab = gradient_table(bvals, bvecs)

--- a/src/nifreeze/data/utils.py
+++ b/src/nifreeze/data/utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import nibabel as nib
+import nibabel as nb
 import nitransforms as nt
 import numpy as np
 
@@ -26,7 +26,7 @@ def apply_affines(nii, em_affines, output_filename=None):
     """
     transformed_nii = np.zeros_like(np.asanyarray(nii.dataobj))
 
-    for ii, bvecnii in enumerate(nib.four_to_three(nii)):
+    for ii, bvecnii in enumerate(nb.four_to_three(nii)):
         xfms = nt.linear.Affine(em_affines[ii])
         transformed_nii[..., ii] = np.asanyarray((~xfms).apply(bvecnii, reference=nii).dataobj)
 

--- a/src/nifreeze/testing/simulations.py
+++ b/src/nifreeze/testing/simulations.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-import nibabel as nib
+import nibabel as nb
 import numpy as np
 from dipy.core.geometry import sphere2cart
 from dipy.core.gradients import gradient_table
@@ -428,8 +428,8 @@ def serialize_dwi(dwi_data, dwi_data_fname, affine: np.ndarray | None = None):
     if affine is None:
         affine = np.eye(4)
 
-    dwi_img = nib.Nifti1Image(dwi_data, affine=affine)
-    nib.save(dwi_img, dwi_data_fname)
+    dwi_img = nb.Nifti1Image(dwi_data, affine=affine)
+    nb.save(dwi_img, dwi_data_fname)
 
 
 def serialize_gtab(gtab, bval_data_fname, bvec_data_fname):

--- a/src/nifreeze/utils/ndimage.py
+++ b/src/nifreeze/utils/ndimage.py
@@ -24,13 +24,13 @@
 import os
 import typing
 
-import nibabel as nib
+import nibabel as nb
 
-ImgT = typing.TypeVar("ImgT", bound=nib.filebasedimages.FileBasedImage)
+ImgT = typing.TypeVar("ImgT", bound=nb.filebasedimages.FileBasedImage)
 
 
 def load_api(path: str | os.PathLike[str], api: type[ImgT]) -> ImgT:
-    img = nib.load(path)
+    img = nb.load(path)
     if not isinstance(img, api):
         raise TypeError(f"File {path} does not implement {api} interface")
     return img

--- a/test/test_data_utils.py
+++ b/test/test_data_utils.py
@@ -1,4 +1,4 @@
-import nibabel as nib
+import nibabel as nb
 import numpy as np
 import numpy.testing as npt
 
@@ -12,7 +12,7 @@ def test_apply_affines():
     nii_data = rng.random((10, 10, 10, 10))
 
     # Generate Nifti1Image
-    nii = nib.Nifti1Image(nii_data, np.eye(4))
+    nii = nb.Nifti1Image(nii_data, np.eye(4))
 
     # Generate synthetic affines
     em_affines = np.expand_dims(np.eye(4), 0).repeat(nii_data.shape[-1], 0)


### PR DESCRIPTION
Use the same alias consistently to import `nibabel`: prefer using `nb` over `nib` as it is more popular across `nipreps` (used in 273 files vs. 13 as of Jan 8, 2025).