### PR TITLE
STYLE: Enforce `flake8` import conventions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ select = [
   "W",
   "B",
   "I",
+  "ICN",
 ]
 ignore = [
   "E203"
@@ -162,6 +163,9 @@ inline-quotes = "double"
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+"nibabel" = "nb"
 
 [tool.ruff.lint.isort]
 known-first-party=["nifreeze"]


### PR DESCRIPTION
Enforce `flake8` import conventions.

Add `nb` as the unconventional import alias for `nibabel` so that every time `nibabel` needs to be imported it is imported as `nb` consistently.

Documentation:
https://docs.astral.sh/ruff/rules/#flake8-import-conventions-icn