### PR TITLE
ENH: Test absent mask warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,8 +184,6 @@ filterwarnings = [
   "ignore:Updating b0_threshold to.*:UserWarning",
   # scikit-learn
   "ignore:The optimal value found for dimension.*:sklearn.exceptions.ConvergenceWarning",
-  # masks
-  "ignore:No mask provided;.*:UserWarning",
 ]
 
 

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -28,6 +28,10 @@ import numpy as np
 
 from nifreeze.exceptions import ModelNotFittedError
 
+mask_absence_warn_msg = (
+    "No mask provided; consider using a mask to avoid issues in model optimization."
+)
+
 
 class ModelFactory:
     """A factory for instantiating data models."""
@@ -96,7 +100,7 @@ class BaseModel:
 
         # Setup brain mask
         if mask is None:
-            warn("No mask provided; consider using a mask to avoid issues in model optimization.")
+            warn(mask_absence_warn_msg)
 
         self._mask = mask
 


### PR DESCRIPTION
Test absent mask warning: parameterize the trivial model test so that the warning raised for the case where the model is instatiated without a mask can be tested.

Remove the corresponding message from the `filterwarnings` list.