### PR TITLE
MAINT: Update minimum required `scikit-learn` version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy>=1.17.3",
     "nest-asyncio>=1.5.1",
     "scikit-image>=0.14.2",
-    "scikit_learn>=0.18",
+    "scikit_learn>=1.3.0",
     "scipy>=1.8.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Update minimum required `scikit-learn` version to 1.3.0 (released June 2023):
- 0.18 dates back to Sept 28, 2016 (9 years ago): https://scikit-learn.org/1.6/whats_new/v0.18.html#changes-0-18
- CI testing is using 1.6.0, the most recent version to date: https://scikit-learn.org/1.6/whats_new/v1.6.html
- Following the errors discovered during the type hinting efforts, the `DiffusionGPR` class is accepting the `n_targets` named parameter constraint, which was introduced in `scikit-learn` version 1.3.0: https://scikit-learn.org/1.6/whats_new/v1.3.html#sklearn-gaussian-process

Documentation:
https://scikit-learn.org/1.6/whats_new/v1.3.html#version-1-3-0