### PR TITLE
MAINT: Bump dependencies versions that support Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "dipy>=1.3.0",
+    "dipy>=1.5.0",
     "joblib",
     "nipype>= 1.5.1,<2.0",
     "nitransforms>=21.0.0,<24",
     "nireports",
-    "numpy>=1.17.3",
+    "numpy>=1.21.3",
     "nest-asyncio>=1.5.1",
-    "scikit-image>=0.14.2",
+    "scikit-image>=0.15.0",
     "scikit_learn>=0.18",
     "scipy>=1.8.0",
 ]


### PR DESCRIPTION
Bump dependencies versions that support Python 3.10, which is the minimum version `NiFreeze` requires:
- `DIPY` 1.5.0 is the first version supporting Python 3.10: https://github.com/dipy/dipy/blob/009c6fe781016370577fa052eee3c26bd25fbd10/doc/old_highlights.rst#older-highlights
- `NumPy` 1.21.3 is the first version supporting Python 3.10: https://numpy.org/doc/stable/release/1.21.3-notes.html#numpy-1-21-3-release-notes
- Users of Python 3.5 or later should be using `scikit-image` 0.15.x or later: https://github.com/scikit-image/scikit-image/blob/main/doc/source/release_notes/release_0.14.rst#scikit-image-0144-2019-09-04