### PR TITLE
ENH: Implicitly-pipelined and modality-agnostic ``Estimator``

### DIFF
--- a/docs/notebooks/bold_realignment.ipynb
+++ b/docs/notebooks/bold_realignment.ipynb
@@ -337,7 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nifreeze.model.base import AverageModel\n",
+    "from nifreeze.model.base import ExpectationModel\n",
     "from nifreeze.utils.iterators import random_iterator"
    ]
   },
@@ -358,7 +358,7 @@
     "        t_mask[t] = True\n",
     "\n",
     "        # Fit and predict using the model\n",
-    "        model = AverageModel()\n",
+    "        model = ExpectationModel()\n",
     "        model.fit(\n",
     "            data[..., ~t_mask],\n",
     "            stat=\"median\",\n",
@@ -376,7 +376,7 @@
     "            fixedmask_path=brainmask_path,\n",
     "            output_transform_prefix=f\"conversion-{t:02d}\",\n",
     "            num_threads=8,\n",
-    "        )\n",
+    "        ).cmdline\n",
     "\n",
     "        # Run the command\n",
     "        proc = await asyncio.create_subprocess_shell(\n",

--- a/scripts/optimize_registration.py
+++ b/scripts/optimize_registration.py
@@ -133,7 +133,7 @@ async def train_coro(
                 fixedmask_path=brainmask_path,
                 output_transform_prefix=f"conversion-{index:04d}",
                 **align_kwargs,
-            )
+            ).cmdline
 
             tasks.append(
                 ants(

--- a/src/nifreeze/cli/run.py
+++ b/src/nifreeze/cli/run.py
@@ -42,12 +42,17 @@ def main(argv=None) -> None:
     # Open the data with the given file path
     dataset: BaseDataset = BaseDataset.from_filename(args.input_file)
 
-    estimator: Estimator = Estimator()
+    prev_model: Estimator | None = None
+    for model in args.models:
+        estimator: Estimator = Estimator(
+            args.model,
+            prev=prev_model,
+        )
+        prev_model = estimator
 
     _ = estimator.run(
         dataset,
         align_kwargs=args.align_config,
-        models=args.models,
         omp_nthreads=args.nthreads,
         njobs=args.njobs,
         seed=args.seed,

--- a/src/nifreeze/cli/run.py
+++ b/src/nifreeze/cli/run.py
@@ -45,7 +45,7 @@ def main(argv=None) -> None:
     prev_model: Estimator | None = None
     for _model in args.models:
         estimator: Estimator = Estimator(
-            args.model,
+            _model,
             prev=prev_model,
         )
         prev_model = estimator

--- a/src/nifreeze/cli/run.py
+++ b/src/nifreeze/cli/run.py
@@ -25,7 +25,7 @@
 from pathlib import Path
 
 from nifreeze.cli.parser import parse_args
-from nifreeze.data.dmri import DWI
+from nifreeze.data.base import BaseDataset
 from nifreeze.estimator import Estimator
 
 
@@ -40,12 +40,12 @@ def main(argv=None) -> None:
     args = parse_args(argv)
 
     # Open the data with the given file path
-    dwi_dataset: DWI = DWI.from_filename(args.input_file)
+    dataset: BaseDataset = BaseDataset.from_filename(args.input_file)
 
     estimator: Estimator = Estimator()
 
-    _ = estimator.estimate(
-        dwi_dataset,
+    _ = estimator.run(
+        dataset,
         align_kwargs=args.align_config,
         models=args.models,
         omp_nthreads=args.nthreads,
@@ -58,7 +58,7 @@ def main(argv=None) -> None:
     output_path: Path = Path(args.output_dir) / output_filename
 
     # Save the DWI dataset to the output path
-    dwi_dataset.to_filename(output_path)
+    dataset.to_filename(output_path)
 
 
 if __name__ == "__main__":

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -137,7 +137,7 @@ class Estimator:
 
                     # fit the model
                     test_set = dataset[i]
-                    predicted = self._model.fit_predict(
+                    predicted = self._model.fit_predict(  # type: ignore[union-attr]
                         i,
                         n_jobs=n_jobs,
                     )

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -117,6 +117,7 @@ class Estimator:
             )
 
         kwargs["num_threads"] = kwargs.pop("omp_nthreads", None) or kwargs.pop("num_threads", None)
+        kwargs = self._align_kwargs | kwargs
 
         dataset_length = len(dataset)
         with TemporaryDirectory() as tmp_dir:

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Self
+from typing import Self, TypeVar
 
 from tqdm import tqdm
 
@@ -38,11 +38,13 @@ from nifreeze.registration.ants import (
 )
 from nifreeze.utils import iterators
 
+DatasetT = TypeVar("DatasetT", bound=BaseDataset)
+
 
 class Filter:
     """Alters an input data object (e.g., downsampling)."""
 
-    def run(self, dataset: BaseDataset, **kwargs):
+    def run(self, dataset: DatasetT, **kwargs) -> DatasetT:
         """
         Trigger execution of the designated filter.
 
@@ -53,8 +55,8 @@ class Filter:
 
         Returns
         -------
-        :obj:`~nifreeze.estimator.Estimator`
-            The estimator, after fitting.
+        dataset : :obj:`~nifreeze.data.base.BaseDataset`
+            The dataset, after filtering.
 
         """
         return dataset
@@ -69,7 +71,7 @@ class Estimator:
         self,
         model: BaseModel | str,
         strategy: str = "random",
-        prev: Self | None = None,
+        prev: Estimator | Filter | None = None,
         model_kwargs: dict | None = None,
         **kwargs,
     ):
@@ -79,7 +81,7 @@ class Estimator:
         self._model_kwargs = model_kwargs or {}
         self._align_kwargs = kwargs or {}
 
-    def run(self, dataset: BaseDataset, **kwargs):
+    def run(self, dataset: DatasetT, **kwargs) -> Self:
         """
         Trigger execution of the workflow this estimator belongs.
 

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -99,7 +99,7 @@ class Estimator:
         if self._prev is not None:
             result = self._prev.run(dataset, **kwargs)
             if isinstance(self._prev, Filter):
-                dataset = result
+                dataset = result  # type: ignore[assignment]
 
         n_jobs = kwargs.get("n_jobs", None)
 

--- a/src/nifreeze/model/__init__.py
+++ b/src/nifreeze/model/__init__.py
@@ -23,7 +23,7 @@
 """Data models."""
 
 from nifreeze.model.base import (
-    AverageModel,
+    ExpectationModel,
     ModelFactory,
     TrivialModel,
 )
@@ -37,7 +37,7 @@ from nifreeze.model.pet import PETModel
 
 __all__ = (
     "ModelFactory",
-    "AverageModel",
+    "ExpectationModel",
     "AverageDWIModel",
     "DKIModel",
     "DTIModel",

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -24,8 +24,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 from dipy.core.gradients import GradientTable
 from dipy.reconst.base import ReconstModel
@@ -268,23 +266,3 @@ class GPFit:
 
         """
         return gp_prediction(self.model, gtab, mask=self.mask)
-
-
-def _rasb2dipy(gradient):
-    gradient = np.asanyarray(gradient)
-    if gradient.ndim == 1:
-        if gradient.size != 4:
-            raise ValueError("Missing gradient information.")
-        gradient = gradient[..., np.newaxis]
-
-    if gradient.shape[0] != 4:
-        gradient = gradient.T
-    elif gradient.shape == (4, 4):
-        print("Warning: make sure gradient information is not transposed!")
-
-    with warnings.catch_warnings():
-        from dipy.core.gradients import gradient_table
-
-        warnings.filterwarnings("ignore", category=UserWarning)
-        retval = gradient_table(gradient[3, :], bvecs=gradient[:3, :].T)
-    return retval

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -22,6 +22,7 @@
 #
 """Base infrastructure for nifreeze's models."""
 
+from abc import abstractmethod
 from warnings import warn
 
 import numpy as np
@@ -95,7 +96,8 @@ class BaseModel:
         if dataset.brainmask is None:
             warn(mask_absence_warn_msg, stacklevel=2)
 
-    def fit_predict(self, *_, **kwargs):
+    @abstractmethod
+    def fit_predict(self, index, **kwargs) -> np.ndarray:
         """Fit and predict the indicate index of the dataset (abstract signature)."""
         raise NotImplementedError("Cannot call fit_predict() on a BaseModel instance.")
 
@@ -139,7 +141,7 @@ class ExpectationModel(BaseModel):
         super().__init__(dataset, **kwargs)
         self._stat = stat
 
-    def fit_predict(self, index, *_, **kwargs):
+    def fit_predict(self, index, **kwargs):
         """
         Return the expectation map.
 

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -44,7 +44,7 @@ class ModelFactory:
         ----------
         model : :obj:`str`
             Diffusion model.
-            Options: ``"DTI"``, ``"DKI"``, ``"S0"``, ``"AverageDW"``
+            Options: ``"DTI"``, ``"DKI"``, ``"S0"``, ``"AverageDWI"``
 
         Return
         ------
@@ -84,9 +84,7 @@ class BaseModel:
 
     """
 
-    __slots__ = {
-        "_dataset": "Reference to a :obj:`~nifreeze.data.base.BaseDataset` object.",
-    }
+    __slots__ = ("_dataset", )
 
     def __init__(self, dataset, **kwargs):
         """Base initialization."""
@@ -105,10 +103,7 @@ class BaseModel:
 class TrivialModel(BaseModel):
     """A trivial model that returns a given map always."""
 
-    __slots__ = {
-        "_predicted": "A :obj:`~numpy.ndarray` with shape matching the dataset containing the map"
-        "that will always be returned as prediction (that is, a reference volume).",
-    }
+    __slots__ = ("_predicted", )
 
     def __init__(self, dataset, predicted=None, **kwargs):
         """Implement object initialization."""
@@ -134,7 +129,7 @@ class TrivialModel(BaseModel):
 class ExpectationModel(BaseModel):
     """A trivial model that returns an expectation map (for example, average)."""
 
-    __slots__ = {"_stat": "The statistical operation to obtain the expectation map."}
+    __slots__ = ("_stat", )
 
     def __init__(self, dataset, stat="median", **kwargs):
         """Initialize a new model."""

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -96,7 +96,10 @@ class BaseModel:
 
         # Setup brain mask
         if mask is None:
-            warn("No mask provided; consider using a mask to avoid issues in model optimization.")
+            warn(
+                "No mask provided; consider using a mask to avoid issues in model optimization.",
+                stacklevel=2,
+            )
 
         self._mask = mask
 

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -84,7 +84,7 @@ class BaseModel:
 
     """
 
-    __slots__ = ("_dataset", )
+    __slots__ = ("_dataset",)
 
     def __init__(self, dataset, **kwargs):
         """Base initialization."""
@@ -103,7 +103,7 @@ class BaseModel:
 class TrivialModel(BaseModel):
     """A trivial model that returns a given map always."""
 
-    __slots__ = ("_predicted", )
+    __slots__ = ("_predicted",)
 
     def __init__(self, dataset, predicted=None, **kwargs):
         """Implement object initialization."""
@@ -129,7 +129,7 @@ class TrivialModel(BaseModel):
 class ExpectationModel(BaseModel):
     """A trivial model that returns an expectation map (for example, average)."""
 
-    __slots__ = ("_stat", )
+    __slots__ = ("_stat",)
 
     def __init__(self, dataset, stat="median", **kwargs):
         """Initialize a new model."""

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -33,7 +33,7 @@ class ModelFactory:
     """A factory for instantiating data models."""
 
     @staticmethod
-    def init(model="DTI", **kwargs):
+    def init(model=None, **kwargs):
         """
         Instantiate a diffusion model.
 
@@ -49,6 +49,9 @@ class ModelFactory:
             A model object compliant with DIPY's interface.
 
         """
+        if model is None:
+            raise RuntimeError("No model identifier provided.")
+
         if model.lower() in ("s0", "b0"):
             return TrivialModel(predicted=kwargs.pop("S0"), gtab=kwargs.pop("gtab"))
 
@@ -143,7 +146,7 @@ class TrivialModel(BaseModel):
         """Do nothing."""
 
     def predict(self, *_, **kwargs):
-        """Return the *b=0* map."""
+        """Return the reference map."""
 
         # No need to check fit (if not fitted, has raised already)
         return self._predicted

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -26,9 +26,11 @@ from importlib import import_module
 import numpy as np
 from joblib import Parallel, delayed
 
-from nifreeze.exceptions import ModelNotFittedError
-from nifreeze.model._dipy import _rasb2dipy
-from nifreeze.model.base import BaseModel
+from nifreeze.data.dmri import (
+    DEFAULT_CLIP_PERCENTILE,
+    DTI_MIN_ORIENTATIONS,
+)
+from nifreeze.model.base import BaseModel, ExpectationModel
 
 
 def _exec_fit(model, data, chunk=None):
@@ -41,84 +43,49 @@ def _exec_predict(model, chunk=None, **kwargs):
     return np.squeeze(model.predict(**kwargs)), chunk
 
 
-DEFAULT_CLIP_PERCENTILE = 75
-"""Upper percentile threshold for intensity clipping."""
-
-DEFAULT_MIN_S0 = 1e-5
-"""Minimum value when considering the :math:`S_{0}` DWI signal."""
-
-DEFAULT_MAX_S0 = 1.0
-"""Maximum value when considering the :math:`S_{0}` DWI signal."""
-
-DEFAULT_MAX_BVALUE = 1000
-"""Maximum allowed value for the b-value."""
-
-DEFAULT_LOWB_THRESHOLD = 50
-"""The lower bound for the b-value so that the orientation is considered a DW volume."""
-
-DEFAULT_HIGHB_THRESHOLD = 10000
-"""A b-value cap for DWI data."""
-
-DEFAULT_NUM_BINS = 15
-"""Number of bins to classify b-values."""
-
-DEFAULT_MULTISHELL_BIN_COUNT_THR = 7
-"""Default bin count to consider a multishell scheme."""
-
-DEFAULT_MAX_BVAL = 8000
-"""Maximum b-value cap."""
-
-
 class BaseDWIModel(BaseModel):
     """Interface and default methods for DWI models."""
 
-    __slots__ = (
-        "_gtab",
-        "_S0",
-        "_b_max",
-        "_model_class",  # Defining a model class, DIPY models are instantiated automagically
-        "_modelargs",
-    )
+    __slots__ = {
+        "_model_class": "Defining a model class, DIPY models are instantiated automagically",
+        "_modelargs": "Arguments acceptable by the underlying DIPY-like model.",
+    }
 
-    def __init__(self, gtab, S0=None, b_max=None, **kwargs):
-        """Initialization.
+    def __init__(self, dataset, **kwargs):
+        r"""Initialization.
 
         Parameters
         ----------
-        gtab : :obj:`numpy.ndarray`
-            An :math:`N \times 4` table, where rows (*N*) are diffusion gradients and
-            columns are b-vector components and corresponding b-value, respectively.
-        S0 : :obj:`numpy.ndarray`
-            :math:`S_{0}` signal.
-        b_max : :obj:`int`
-            Maximum value to cap b-values.
+        dataset : :obj:`~nifreeze.data.dmri.DWI`
+            Reference to a DWI object.
 
         """
 
-        super().__init__(**kwargs)
+        # Duck typing, instead of explicitly test for DWI type
+        if not hasattr(dataset, "bzero"):
+            raise TypeError("Dataset MUST be a DWI object.")
 
-        # Setup B0 map
-        self._S0 = None
-        if S0 is not None:
-            self._S0 = np.clip(
-                S0.astype("float32") / S0.max(),
-                a_min=DEFAULT_MIN_S0,
-                a_max=DEFAULT_MAX_S0,
+        if not hasattr(dataset, "gradients") or dataset.gradients is None:
+            raise ValueError("Dataset MUST have a gradient table.")
+
+        if dataset.gradients.shape[0] < DTI_MIN_ORIENTATIONS:
+            raise ValueError(
+                f"DWI dataset is too small ({dataset.gradients.shape[0]} directions)."
             )
 
-        # Cap b-values, if requested
-        self._gtab = gtab
-        self._b_max = None
-        if b_max and b_max > DEFAULT_MAX_BVALUE:
-            # Saturate b-values at b_max, since signal stops dropping
-            self._gtab[-1, self._gtab[-1] > b_max] = b_max
-            # A possibly good alternative is completely remove very high b-values
-            # bval_mask = gtab[-1] < b_max
-            # data = data[..., bval_mask]
-            # gtab = gtab[:, bval_mask]
-            self._b_max = b_max
+        super().__init__(dataset, **kwargs)
 
-        kwargs = {k: v for k, v in kwargs.items() if k in self._modelargs}
+    def _fit(self, index, n_jobs=None, **kwargs):
+        """Fit the model chunk-by-chunk asynchronously"""
+        n_jobs = n_jobs or 1
+
+        brainmask = self._dataset.brainmask
+        idxmask = np.ones(len(self._dataset), dtype=bool)
+        idxmask[index] = False
+
+        data, _, gtab = self._dataset[idxmask]
+        # Select voxels within mask or just unravel 3D if no mask
+        data = data[brainmask, ...] if brainmask is not None else data.reshape(-1, data.shape[-1])
 
         # DIPY models (or one with a fully-compliant interface)
         model_str = getattr(self, "_model_class", None)
@@ -127,18 +94,7 @@ class BaseDWIModel(BaseModel):
             self._model = getattr(
                 import_module(module_name),
                 class_name,
-            )(_rasb2dipy(gtab), **kwargs)
-
-    def fit(self, data, n_jobs=None, **kwargs):
-        """Fit the model chunk-by-chunk asynchronously"""
-        n_jobs = n_jobs or 1
-
-        self._datashape = data.shape
-
-        # Select voxels within mask or just unravel 3D if no mask
-        data = (
-            data[self._mask, ...] if self._mask is not None else data.reshape(-1, data.shape[-1])
-        )
+            )(gtab, **kwargs)
 
         # One single CPU - linear execution (full model)
         if n_jobs == 1:
@@ -155,37 +111,31 @@ class BaseDWIModel(BaseModel):
             results = executor(
                 delayed(_exec_fit)(self._model, dchunk, i) for i, dchunk in enumerate(data_chunks)
             )
-        for submodel, index in results:
-            self._models[index] = submodel
+        for submodel, rindex in results:
+            self._models[rindex] = submodel
 
-        self._is_fitted = True
         self._model = None  # Preempt further actions on the model
+        return n_jobs
 
-    def predict(self, gradient=None, **kwargs):
-        """Predict asynchronously chunk-by-chunk the diffusion signal."""
+    def fit_predict(self, index, **kwargs):
+        """
+        Predict asynchronously chunk-by-chunk the diffusion signal.
 
-        if gradient is None:
-            raise ValueError("A gradient to be simulated (b-vector, b-value) must be provided")
+        Parameters
+        ----------
+        index : :obj:`int`
+            The volume index that is left-out in fitting, and then predicted.
 
-        if not self._is_fitted:
-            raise ModelNotFittedError(f"{type(self).__name__} must be fitted before predicting")
+        """
 
-        gradient = np.array(gradient)  # Tuples are unmutable
+        n_models = self._fit(index, **kwargs)
 
-        # Cap the b-value if b_max is defined
-        gradient[-1] = min(gradient[-1], self._b_max or gradient[-1])
+        brainmask = self._dataset.brainmask
+        gradient = self._dataset.gradients[index]
 
-        gradient = _rasb2dipy(gradient)
-
-        S0 = None
-        if self._S0 is not None:
-            S0 = (
-                self._S0[self._mask, ...]
-                if self._mask is not None
-                else self._S0.reshape(-1, self._S0.shape[-1])
-            )
-
-        n_models = len(self._models) if self._model is None and self._models else 1
+        S0 = self._dataset.bzero
+        if S0 is not None:
+            S0 = S0[brainmask, ...] if brainmask is not None else S0.reshape(-1)
 
         if n_models == 1:
             predicted, _ = _exec_predict(self._model, **(kwargs | {"gtab": gradient, "S0": S0}))
@@ -209,21 +159,21 @@ class BaseDWIModel(BaseModel):
 
             predicted = np.hstack(predicted)
 
-        if self._mask is not None:
-            retval = np.zeros_like(self._mask, dtype="float32")
-            retval[self._mask, ...] = predicted
+        if brainmask is not None:
+            retval = np.zeros_like(brainmask, dtype="float32")
+            retval[brainmask, ...] = predicted
         else:
-            retval = predicted.reshape(self._datashape[:-1])
+            retval = predicted.reshape(self._dataset.shape[:-1])
 
         return retval
 
 
-class AverageDWIModel(BaseDWIModel):
+class AverageDWIModel(ExpectationModel):
     """A trivial model that returns an average DWI volume."""
 
-    __slots__ = ("_data", "_th_low", "_th_high", "_bias", "_stat", "_is_fitted")
+    __slots__ = ("_th_low", "_th_high", "_detrend")
 
-    def __init__(self, **kwargs):
+    def __init__(self, dataset, stat="median", th_low=100, th_high=100, detrend=False, **kwargs):
         r"""
         Implement object initialization.
 
@@ -235,7 +185,7 @@ class AverageDWIModel(BaseDWIModel):
         th_high : :obj:`numbers.Number`
             An upper bound for the b-value corresponding to the diffusion weighted images
             that will be averaged.
-        bias : :obj:`bool`
+        detrend : :obj:`bool`
             Whether the overall distribution of each diffusion weighted image will be
             standardized and centered around the
             :data:`src.nifreeze.model.base.DEFAULT_CLIP_PERCENTILE` percentile.
@@ -243,49 +193,42 @@ class AverageDWIModel(BaseDWIModel):
             Whether the summary statistic to apply is ``"mean"`` or ``"median"``.
 
         """
-        super().__init__(**kwargs)
+        super().__init__(dataset, stat=stat, **kwargs)
 
-        self._th_low = kwargs.get("th_low", DEFAULT_LOWB_THRESHOLD)
-        self._th_high = kwargs.get("th_high", DEFAULT_HIGHB_THRESHOLD)
-        self._bias = kwargs.get("bias", True)
-        self._stat = kwargs.get("stat", "median")
-        self._data = None
+        self._th_low = th_low
+        self._th_high = th_high
+        self._detrend = detrend
 
-    def fit(self, data, **kwargs):
-        """Calculate the average."""
+    def fit_predict(self, index, *_, **kwargs):
+        """Return the average map."""
 
-        if (gtab := kwargs.pop("gtab", None)) is None:
-            raise ValueError("A gradient table must be provided.")
+        bvalues = self._dataset.gradients[:, -1]
+        bcenter = bvalues[index]
 
-        # Select the interval of b-values for which DWIs will be averaged
-        b_mask = (
-            ((gtab[3] >= self._th_low) & (gtab[3] <= self._th_high))
-            if gtab is not None
-            else np.ones((data.shape[-1],), dtype=bool)
-        )
-        shells = data[..., b_mask]
+        shellmask = np.ones(len(self._dataset), dtype=bool)
+
+        # Keep only bvalues within the range defined by th_high and th_low
+        shellmask[index] = False
+        shellmask[bvalues > (bcenter + self._th_high)] = False
+        shellmask[bvalues < (bcenter - self._th_low)] = False
+
+        if not shellmask.sum():
+            raise RuntimeError(f"Shell corresponding to index {index} (b={bcenter}) is empty.")
+
+        shelldata = self._dataset.dataobj[..., shellmask]
 
         # Regress out global signal differences
-        if self._bias:
-            centers = np.median(shells, axis=(0, 1, 2))
+        if self._detrend:
+            centers = np.median(shelldata, axis=(0, 1, 2))
             reference = np.percentile(centers[centers >= 1.0], DEFAULT_CLIP_PERCENTILE)
             centers[centers < 1.0] = reference
             drift = reference / centers
-            shells = shells * drift
+            shelldata = shelldata * drift
 
         # Select the summary statistic
         avg_func = np.median if self._stat == "median" else np.mean
         # Calculate the average
-        self._data = avg_func(shells, axis=-1)
-        self._is_fitted = True
-
-    def predict(self, *_, **kwargs):
-        """Return the average map."""
-
-        if not self._is_fitted:
-            raise ModelNotFittedError(f"{type(self).__name__} must be fitted before predicting")
-
-        return self._data
+        return avg_func(shelldata, axis=-1)
 
 
 class DTIModel(BaseDWIModel):
@@ -314,65 +257,3 @@ class GPModel(BaseDWIModel):
 
     _modelargs = ("kernel_model",)
     _model_class = "nifreeze.model._dipy.GaussianProcessModel"
-
-
-def find_shelling_scheme(
-    bvals,
-    num_bins=DEFAULT_NUM_BINS,
-    multishell_nonempty_bin_count_thr=DEFAULT_MULTISHELL_BIN_COUNT_THR,
-    bval_cap=DEFAULT_MAX_BVAL,
-):
-    """
-    Find the shelling scheme on the given b-values.
-
-    Computes the histogram of the b-values according to ``num_bins``
-    and depending on the nonempty bin count, classify the shelling scheme
-    as single-shell if they are 2 (low-b and a shell); multi-shell if they are
-    below the ``multishell_nonempty_bin_count_thr`` value; and DSI otherwise.
-
-    Parameters
-    ----------
-    bvals : :obj:`list` or :obj:`~numpy.ndarray`
-         List or array of b-values.
-    num_bins : :obj:`int`, optional
-        Number of bins.
-    multishell_nonempty_bin_count_thr : :obj:`int`, optional
-        Bin count to consider a multi-shell scheme.
-
-    Returns
-    -------
-    scheme : :obj:`str`
-        Shelling scheme.
-    bval_groups : :obj:`list`
-        List of grouped b-values.
-    bval_estimated : :obj:`list`
-        List of 'estimated' b-values as the median value of each b-value group.
-
-    """
-
-    # Bin the b-values: use -1 as the lower bound to be able to appropriately
-    # include b0 values
-    hist, bin_edges = np.histogram(bvals, bins=num_bins, range=(-1, min(max(bvals), bval_cap)))
-
-    # Collect values in each bin
-    bval_groups = []
-    bval_estimated = []
-    for lower, upper in zip(bin_edges[:-1], bin_edges[1:], strict=False):
-        # Add only if a nonempty b-values mask
-        if (mask := (bvals > lower) & (bvals <= upper)).sum():
-            bval_groups.append(bvals[mask])
-            bval_estimated.append(np.median(bvals[mask]))
-
-    nonempty_bins = len(bval_groups)
-
-    if nonempty_bins < 2:
-        raise ValueError("DWI must have at least one high-b shell")
-
-    if nonempty_bins == 2:
-        scheme = "single-shell"
-    elif nonempty_bins < multishell_nonempty_bin_count_thr:
-        scheme = "multi-shell"
-    else:
-        scheme = "DSI"
-
-    return scheme, bval_groups, bval_estimated

--- a/src/nifreeze/registration/ants.py
+++ b/src/nifreeze/registration/ants.py
@@ -130,7 +130,6 @@ def _prepare_registration_data(
 
     """
     clip = clip or "none"
-
     predicted_path = Path(dirname) / f"predicted_{vol_idx:05d}.nii.gz"
     sample_path = Path(dirname) / f"sample_{vol_idx:05d}.nii.gz"
     _to_nifti(
@@ -151,7 +150,7 @@ def _prepare_registration_data(
         ImageGrid = namedtuple("ImageGrid", ("shape", "affine"))
         reference = ImageGrid(shape=sample.shape[:3], affine=affine)
         initial_xform = Affine(matrix=init_affine, reference=reference)
-        init_path = dirname / f"init_{vol_idx:05d}.mat"
+        init_path = Path(dirname) / f"init_{vol_idx:05d}.mat"
         initial_xform.to_filename(init_path, fmt="itk")
 
     return predicted_path, sample_path, init_path

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -100,5 +100,5 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.ensure_newline()
         terminalreporter.section("Werrors", sep="=", red=True, bold=True)
         terminalreporter.line(
-            f"Warnings as errors: Activated.\n{len(have_warnings)} warnings were raised and treated as errors.\n"
+            f"{len(have_warnings)} warnings were raised and treated as errors.\n"
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,8 +26,11 @@ import os
 from pathlib import Path
 
 import nibabel as nb
+import nitransforms as nt
 import numpy as np
 import pytest
+
+from nifreeze.data.dmri import DWI
 
 test_data_env = os.getenv("TEST_DATA_HOME", str(Path.home() / "nifreeze-tests"))
 test_output_dir = os.getenv("TEST_OUTPUT_DIR")
@@ -54,19 +57,19 @@ def doctest_imports(doctest_namespace):
     doctest_namespace["repodata"] = _datadir
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def outdir():
     """Determine if test artifacts should be stored somewhere or deleted."""
     return None if test_output_dir is None else Path(test_output_dir)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def datadir():
     """Return a data path outside the package's structure (i.e., large datasets)."""
     return Path(test_data_env)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def repodata():
     """Return the path to this repository's test data folder."""
     return _datadir
@@ -78,6 +81,59 @@ def pytest_addoption(parser):
         action="store_true",
         help="Consider all uncaught warnings as errors.",
     )
+
+
+@pytest.fixture(scope="session")
+def motion_data(tmp_path_factory, datadir):
+    # Temporary directory for session-scoped fixtures
+    tmp_path = tmp_path_factory.mktemp("motion_test_data")
+
+    dwdata = DWI.from_filename(datadir / "dwi.h5")
+    b0nii = nb.Nifti1Image(dwdata.bzero, dwdata.affine, None)
+    masknii = nb.Nifti1Image(dwdata.brainmask.astype("uint8"), dwdata.affine, None)
+
+    # Generate a list of large-yet-plausible bulk-head motion
+    xfms = nt.linear.LinearTransformsMapping(
+        [
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=0.03, z=0.005), (0.8, 0.2, 0.2)),
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=0.02, z=0.005), (0.8, 0.2, 0.2)),
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=0.02, z=0.02), (0.4, 0.2, 0.2)),
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=-0.02, z=0.02), (0.4, 0.2, 0.2)),
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=-0.02, z=0.002), (0.0, 0.2, 0.2)),
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(y=-0.02, z=0.002), (0.0, 0.2, 0.2)),
+            nb.affines.from_matvec(nb.eulerangles.euler2mat(y=-0.01, z=0.002), (0.0, 0.4, 0.2)),
+        ],
+        reference=b0nii,
+    )
+
+    # Induce motion into dataset (i.e., apply the inverse transforms)
+    moved_nii = (~xfms).apply(b0nii, reference=b0nii)
+
+    # Save the moved dataset for debugging or further processing
+    moved_path = tmp_path / "test.nii.gz"
+    ground_truth_path = tmp_path / "ground_truth.nii.gz"
+    moved_nii.to_filename(moved_path)
+    xfms.apply(moved_nii).to_filename(ground_truth_path)
+
+    # Wrap into dataset object
+    dwi_motion = DWI(
+        dataobj=np.asanyarray(moved_nii.dataobj),
+        affine=b0nii.affine,
+        bzero=dwdata.bzero,
+        gradients=dwdata.gradients[..., : len(xfms)],
+        brainmask=dwdata.brainmask,
+    )
+
+    # Return data as a dictionary (or any format that makes sense for your tests)
+    return {
+        "b0nii": b0nii,
+        "masknii": masknii,
+        "moved_nii": moved_nii,
+        "xfms": xfms,
+        "moved_path": moved_path,
+        "ground_truth_path": ground_truth_path,
+        "moved_nifreeze": dwi_motion,
+    }
 
 
 @pytest.hookimpl(trylast=True)

--- a/test/test_data_dmri.py
+++ b/test/test_data_dmri.py
@@ -26,10 +26,7 @@ import nibabel as nb
 import numpy as np
 import pytest
 
-from nifreeze.data.dmri import load
-from nifreeze.model.dmri import (
-    find_shelling_scheme,
-)
+from nifreeze.data.dmri import find_shelling_scheme, load
 
 
 def _create_dwi_random_dataobj():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -70,10 +70,9 @@ def test_proximity_estimator_trivial_model(datadir, tmp_path):
         brainmask=dwdata.brainmask,
     )
 
-    estimator = Estimator(dwi_motion, model="b0")
+    estimator = Estimator("b0")
     estimator.run(
-        data=dwi_motion,
-        models=("b0",),
+        dwi_motion,
         seed=None,
         align_kwargs={
             "config_file": "b0-to-b0_level0.json",

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -70,26 +70,25 @@ def test_proximity_estimator_trivial_model(datadir, tmp_path):
         brainmask=dwdata.brainmask,
     )
 
-    estimator = Estimator()
-    em_affines = estimator.estimate(
+    estimator = Estimator(dwi_motion, model="b0")
+    estimator.run(
         data=dwi_motion,
         models=("b0",),
         seed=None,
         align_kwargs={
-            "fixed_modality": "b0",
-            "moving_modality": "b0",
+            "config_file": "b0-to-b0_level0.json",
             "num_threads": min(cpu_count(), 8),
         },
     )
 
     # Uncomment to see the realigned dataset
     nt.linear.LinearTransformsMapping(
-        em_affines,
+        dwi_motion.motion_affines,
         reference=b0nii,
     ).apply(moved_nii).to_filename(tmp_path / "realigned.nii.gz")
 
     # For each moved b0 volume
-    for i, est in enumerate(em_affines):
+    for i, est in enumerate(dwi_motion.motion_affines):
         assert (
             displacements_within_mask(
                 masknii,

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -24,54 +24,22 @@
 
 from os import cpu_count
 
-import nibabel as nb
 import nitransforms as nt
-import numpy as np
 
-from nifreeze.data.dmri import DWI
 from nifreeze.estimator import Estimator
 from nifreeze.model.base import TrivialModel
 from nifreeze.registration.utils import displacements_within_mask
 
 
-def test_proximity_estimator_trivial_model(datadir, tmp_path):
+def test_proximity_estimator_trivial_model(motion_data, tmp_path):
     """Check the proximity of transforms estimated by the estimator with a trivial B0 model."""
 
-    dwdata = DWI.from_filename(datadir / "dwi.h5")
-    b0nii = nb.Nifti1Image(dwdata.bzero, dwdata.affine, None)
-    masknii = nb.Nifti1Image(dwdata.brainmask.astype(np.uint8), dwdata.affine, None)
+    b0nii = motion_data["b0nii"]
+    moved_nii = motion_data["moved_nii"]
+    xfms = motion_data["xfms"]
+    dwi_motion = motion_data["moved_nifreeze"]
 
-    # Generate a list of large-yet-plausible bulk-head motion.
-    xfms = nt.linear.LinearTransformsMapping(
-        [
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=0.03, z=0.005), (0.8, 0.2, 0.2)),
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=0.02, z=0.005), (0.8, 0.2, 0.2)),
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=0.02, z=0.02), (0.4, 0.2, 0.2)),
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=-0.02, z=0.02), (0.4, 0.2, 0.2)),
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(x=-0.02, z=0.002), (0.0, 0.2, 0.2)),
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(y=-0.02, z=0.002), (0.0, 0.2, 0.2)),
-            nb.affines.from_matvec(nb.eulerangles.euler2mat(y=-0.01, z=0.002), (0.0, 0.4, 0.2)),
-        ],
-        reference=b0nii,
-    )
-
-    # Induce motion into dataset (i.e., apply the inverse transforms)
-    moved_nii = (~xfms).apply(b0nii, reference=b0nii)
-
-    # Uncomment to see the moved dataset
-    moved_nii.to_filename(tmp_path / "test.nii.gz")
-    xfms.apply(moved_nii).to_filename(tmp_path / "ground_truth.nii.gz")
-
-    # Wrap into dataset object
-    dwi_motion = DWI(
-        dataobj=moved_nii.dataobj,
-        affine=b0nii.affine,
-        bzero=dwdata.bzero,
-        gradients=dwdata.gradients[..., : len(xfms)],
-        brainmask=dwdata.brainmask,
-    )
-
-    model = TrivialModel(dwdata)
+    model = TrivialModel(dwi_motion)
     estimator = Estimator(model)
     estimator.run(
         dwi_motion,
@@ -89,9 +57,29 @@ def test_proximity_estimator_trivial_model(datadir, tmp_path):
     for i, est in enumerate(dwi_motion.motion_affines):
         assert (
             displacements_within_mask(
-                masknii,
+                motion_data["masknii"],
                 nt.linear.Affine(est),
                 xfms[i],
             ).max()
             < 0.25
         )
+
+
+def test_stacked_estimators(motion_data):
+    """Check that models can be stacked."""
+
+    # Wrap into dataset object
+    dmri_dataset = motion_data["moved_nifreeze"]
+
+    estimator1 = Estimator(
+        TrivialModel(dmri_dataset),
+        ants_config="dwi-to-dwi_level0.json",
+        clip=False,
+    )
+    estimator2 = Estimator(
+        TrivialModel(dmri_dataset),
+        prev=estimator1,
+        clip=False,
+    )
+
+    estimator2.run(dmri_dataset)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from nifreeze.data.dmri import DWI
 from nifreeze.estimator import Estimator
+from nifreeze.model.base import TrivialModel
 from nifreeze.registration.utils import displacements_within_mask
 
 
@@ -70,14 +71,12 @@ def test_proximity_estimator_trivial_model(datadir, tmp_path):
         brainmask=dwdata.brainmask,
     )
 
-    estimator = Estimator("b0")
+    model = TrivialModel(dwdata)
+    estimator = Estimator(model)
     estimator.run(
         dwi_motion,
-        seed=None,
-        align_kwargs={
-            "config_file": "b0-to-b0_level0.json",
-            "num_threads": min(cpu_count(), 8),
-        },
+        seed=12345,
+        num_threads=min(cpu_count(), 8),
     )
 
     # Uncomment to see the realigned dataset

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -78,10 +78,6 @@ def test_trivial_model(use_mask):
 def test_average_model():
     """Check the implementation of the average DW model."""
 
-    size = (100, 100, 100, 6)
-    data = np.ones(size, dtype=float)
-    mask = np.ones(size[:3], dtype=bool)
-
     gtab = np.array(
         [
             [0, 0, 0, 0],
@@ -96,6 +92,10 @@ def test_average_model():
             [0.307, -0.766, 0.677, 2000],
         ]
     )
+
+    size = (100, 100, 100, gtab.shape[0])
+    data = np.ones(size, dtype=float)
+    mask = np.ones(size[:3], dtype=bool)
 
     data *= gtab[:, -1]
     dataset = DWI(dataobj=data, gradients=gtab, brainmask=mask)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -27,11 +27,8 @@ import pytest
 from dipy.sims.voxel import single_tensor
 
 from nifreeze import model
-from nifreeze.data.dmri import DWI
-from nifreeze.data.splitting import lovo_split
-from nifreeze.exceptions import ModelNotFittedError
+from nifreeze.data.dmri import DEFAULT_MAX_S0, DEFAULT_MIN_S0, DWI
 from nifreeze.model._dipy import GaussianProcessModel
-from nifreeze.model.dmri import DEFAULT_MAX_S0, DEFAULT_MIN_S0
 from nifreeze.testing import simulations as _sim
 
 
@@ -52,19 +49,21 @@ def test_trivial_model():
         a_max=DEFAULT_MAX_S0,
     )
 
-    tmodel = model.TrivialModel(predicted=_clipped_S0)
+    data = DWI(
+        dataobj=(*_S0.shape, 10),
+        bzero=_clipped_S0,
+    )
 
-    data = None
-    assert tmodel.fit(data) is None
+    tmodel = model.TrivialModel(data)
+    predicted = tmodel.fit_predict(4)
 
-    assert np.all(_clipped_S0 == tmodel.predict((1, 0, 0)))
+    assert np.all(_clipped_S0 == predicted)
 
 
 def test_average_model():
     """Check the implementation of the average DW model."""
 
-    data = np.ones((100, 100, 100, 6), dtype=float)
-
+    data = np.ones((100, 100, 100, 10), dtype=float)
     gtab = np.array(
         [
             [0, 0, 0, 0],
@@ -72,40 +71,37 @@ def test_average_model():
             [0.25, 0.565, 0.21, 500],
             [-0.861, -0.464, 0.564, 1000],
             [0.307, -0.766, 0.677, 1000],
-            [0.736, 0.013, 0.774, 1300],
+            [0.736, 0.013, 0.774, 1000],
+            [-0.31, 0.933, 0.785, 1000],
+            [0.25, 0.565, 0.21, 2000],
+            [-0.861, -0.464, 0.564, 2000],
+            [0.307, -0.766, 0.677, 2000],
         ]
     )
 
     data *= gtab[:, -1]
+    dataset = DWI(dataobj=data, gradients=gtab)
 
-    tmodel_mean = model.AverageDWIModel(gtab=gtab, bias=False, stat="mean")
-    tmodel_median = model.AverageDWIModel(gtab=gtab, bias=False, stat="median")
-    tmodel_1000 = model.AverageDWIModel(gtab=gtab, bias=False, th_high=1000, th_low=900)
-    tmodel_2000 = model.AverageDWIModel(
-        gtab=gtab,
-        bias=False,
-        th_high=2000,
-        th_low=900,
-        stat="mean",
-    )
+    tmodel_mean = model.AverageDWIModel(dataset, stat="mean")
+    tmodel_mean_full = model.AverageDWIModel(dataset, stat="mean", th_low=2000, th_high=2000)
+    tmodel_median = model.AverageDWIModel(dataset)
 
-    with pytest.raises(ModelNotFittedError):
-        tmodel_mean.predict([0, 0, 0])
+    # Verify that average cannot be calculated in shells with one single value
+    with pytest.raises(RuntimeError):
+        tmodel_mean.fit_predict(2)
 
-    # Verify that fit function returns nothing
-    assert tmodel_mean.fit(data[..., 1:], gtab=gtab[1:].T) is None
+    assert np.allclose(tmodel_mean.fit_predict(3), 1000)
+    assert np.allclose(tmodel_median.fit_predict(3), 1000)
 
-    tmodel_median.fit(data[..., 1:], gtab=gtab[1:].T)
-    tmodel_1000.fit(data[..., 1:], gtab=gtab[1:].T)
-    tmodel_2000.fit(data[..., 1:], gtab=gtab[1:].T)
+    grads = list(gtab[:, -1])
+    del grads[1]
+    assert np.allclose(tmodel_mean_full.fit_predict(1), np.mean(grads))
 
-    # Verify that the right statistics is applied and that the model discard b-values < 50
-    assert np.all(tmodel_mean.predict([0, 0, 0]) == 950)
-    assert np.all(tmodel_median.predict([0, 0, 0]) == 1000)
+    tmodel_mean_2000 = model.AverageDWIModel(dataset, stat="mean", th_low=1100)
+    tmodel_median_2000 = model.AverageDWIModel(dataset, th_low=1100)
 
-    # Verify that the threshold for b-value selection works as expected
-    assert np.all(tmodel_1000.predict([0, 0, 0]) == 1000)
-    assert np.all(tmodel_2000.predict([0, 0, 0]) == 1100)
+    assert np.allclose(tmodel_mean_2000.fit_predict(9), gtab[3:-1, -1].mean())
+    assert np.allclose(tmodel_median_2000.fit_predict(9), 1000)
 
 
 @pytest.mark.parametrize(
@@ -143,42 +139,26 @@ def test_gp_model(evals, S0, snr, hsph_dirs, bval_shell):
     assert prediction.shape == (2,)
 
 
-def test_two_initialisations(datadir):
+def test_factory(datadir):
     """Check that the two different initialisations result in the same models"""
 
     # Load test data
     dmri_dataset = DWI.from_filename(datadir / "dwi.h5")
 
-    # Split data into test and train set
-    data_train, data_test = lovo_split(dmri_dataset, 10)
-
+    modelargs = {
+        "th_low": 25,
+        "th_high": 25,
+        "detrend": True,
+        "stat": "mean",
+    }
     # Direct initialisation
-    model1 = model.AverageDWIModel(
-        gtab=data_train[-1],
-        S0=dmri_dataset.bzero,
-        th_low=100,
-        th_high=1000,
-        bias=False,
-        stat="mean",
-    )
-    model1.fit(data_train[0], gtab=data_train[-1])
-    predicted1 = model1.predict(data_test[-1])
+    model1 = model.AverageDWIModel(dmri_dataset, **modelargs)
 
     # Initialisation via ModelFactory
-    model2 = model.ModelFactory.init(
-        gtab=data_train[-1],
-        model="avgdwi",
-        S0=dmri_dataset.bzero,
-        th_low=100,
-        th_high=1000,
-        bias=False,
-        stat="mean",
-    )
+    model2 = model.ModelFactory.init(model="avgdwi", dataset=dmri_dataset, **modelargs)
 
-    with pytest.raises(ModelNotFittedError):
-        model2.predict(data_test[-1])
-
-    model2.fit(data_train[0], gtab=data_train[-1])
-    predicted2 = model2.predict(data_test[-1])
-
-    assert np.all(predicted1 == predicted2)
+    assert model1._dataset == model2._dataset
+    assert model1._detrend == model2._detrend
+    assert model1._th_low == model2._th_low
+    assert model1._th_high == model2._th_high
+    assert model1._stat == model2._stat


### PR DESCRIPTION
Changes our current implementation of the estimator with a new architecture that allows stacking
(https://github.com/nipreps/nifreeze/issues/12#issuecomment-2598471780):

```Python
estimator_level1 = Estimator(model="b0", ...)    # e.g., 6 dof registration
estimator_level2 = Estimator(model="b0", input=estimator_level1, ...) # e.g., 9 dof registration

estimator_level2.fit(dataset_object)  # Checks "input" and it's another estimator, so runs that first
```

This allow for adding *filters* (to be implemented):

``` Python
downsample = Filter(...)  # e.g., downsampling filter
estimator_level1 = Estimator(model="b0", input=downsample, ...)    # e.g., 6 dof registration
estimator_level2 = Estimator(model="b0", input=estimator_level1, ...) # e.g., 9 dof registration

estimator_level2.fit(dataset_object)  # Checks "input" and it's another estimator, so runs that first
```

In this case, the filtered dataset only feeds ``estimator_level1``. The second level will work on a full dataset.
If you want to interleave another downsampling filter:

``` Python
downsample1 = Filter(...)  # e.g., downsampling filter 1
estimator_level1 = Estimator(model="b0", input=downsample, ...)    # e.g., 6 dof registration
downsample2 = Filter(input=estimator_level1, ...)  # e.g., downsampling filter 2
estimator_level2 = Estimator(model="b0", input=downsaple2, ...) # e.g., 9 dof registration

estimator_level2.fit(dataset_object)  # Checks "input" and it's another estimator, so runs that first
```

Resolves: #12.
Resolves: #21.