### PR TITLE
BUG: Use the appropriate index to extract b-values

### DIFF
--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -233,12 +233,8 @@ class DWI(BaseDataset[np.ndarray | None]):
         # Convert filename to a Path object.
         out_root = Path(filename).absolute()
 
-        # Remove .gz if present, then remove .nii if present.
-        # This yields the base stem for writing .bvec / .bval.
-        if out_root.suffix == ".gz":
-            out_root = out_root.with_suffix("")  # remove '.gz'
-        if out_root.suffix == ".nii":
-            out_root = out_root.with_suffix("")  # remove '.nii'
+        # Get the base stem for writing .bvec / .bval.
+        out_root = out_root.parent / out_root.name.replace("".join(out_root.suffixes), "")
 
         # Construct sidecar file paths.
         bvecs_file = out_root.with_suffix(".bvec")

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -246,8 +246,8 @@ class DWI(BaseDataset[np.ndarray | None]):
 
         # Save bvecs and bvals to text files
         # Each row of bvecs is one direction (3 rows, N columns).
-        np.savetxt(bvecs_file, self.bvecs.T, fmt="%.6f")
-        np.savetxt(bvals_file, self.bvals, fmt="%.6f")
+        np.savetxt(bvecs_file, self.bvecs, fmt="%.6f")
+        np.savetxt(bvals_file, self.bvals[np.newaxis, :], fmt="%.6f")
 
 
 def load(

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -239,7 +239,7 @@ class DWI(BaseDataset[np.ndarray | None]):
         # Save bvecs and bvals to text files
         # Each row of bvecs is one direction (3 rows, N columns).
         np.savetxt(bvecs_file, self.gradients[:3, ...].T, fmt="%.6f")
-        np.savetxt(bvals_file, self.gradients[:3, ...], fmt="%.6f")
+        np.savetxt(bvals_file, self.gradients[-1, ...], fmt="%.6f")
 
 
 def load(

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -208,7 +208,13 @@ class DWI(BaseDataset[np.ndarray | None]):
         with h5py.File(filename, "r+") as out_file:
             out_file.attrs["Type"] = "dmri"
 
-    def to_nifti(self, filename: Path | str, insert_b0: bool = False) -> None:
+    def to_nifti(
+        self,
+        filename: Path | str,
+        insert_b0: bool = False,
+        bvals_dec_places: int = 2,
+        bvecs_dec_places: int = 6,
+    ) -> None:
         """
         Write a NIfTI file to disk.
 
@@ -218,6 +224,10 @@ class DWI(BaseDataset[np.ndarray | None]):
             The output NIfTI file path.
         insert_b0 : :obj:`bool`, optional
             Insert a :math:`b=0` at the front of the output NIfTI.
+        bvals_dec_places : :obj:`int`, optional
+            Decimal places to use when serializing b-values.
+        bvecs_dec_places : :obj:`int`, optional
+            Decimal places to use when serializing b-vectors.
 
         """
         if not insert_b0:
@@ -242,8 +252,8 @@ class DWI(BaseDataset[np.ndarray | None]):
 
         # Save bvecs and bvals to text files
         # Each row of bvecs is one direction (3 rows, N columns).
-        np.savetxt(bvecs_file, self.bvecs, fmt="%.6f")
-        np.savetxt(bvals_file, self.bvals[np.newaxis, :], fmt="%.6f")
+        np.savetxt(bvecs_file, self.bvecs, fmt=f"%.{bvecs_dec_places}f")
+        np.savetxt(bvals_file, self.bvals[np.newaxis, :], fmt=f"%.{bvals_dec_places}f")
 
 
 def load(

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -216,7 +216,7 @@ class DWI(BaseDataset[np.ndarray | None]):
         ----------
         filename : :obj:`os.pathlike`
             The output NIfTI file path.
-        insert_b0 : :obj:`bool`
+        insert_b0 : :obj:`bool`, optional
             Insert a :math:`b=0` at the front of the output NIfTI.
 
         """


### PR DESCRIPTION
- BUG: Use the appropriate index to extract b-values
- STYLE: Add gradient-related properties to DWI data class
- STYLE: Make bvecs/bvals serialized shapes match comments/expectations
- STYLE: Simplify getting the root name for DWI serialization
- DOC: Mark the `insert_b0` parameter as optional
- ENH: Add decimal places for bval/bvec serialization