### PR TITLE
MAINT: Fix `notebooks` testing configuration `env` warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ pass_env =
   PYTHONHASHSEED
   ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
   PATH
-extras = notebooks
+extras = test, notebooks
 commands =
    # pytest --nbmake docs/notebooks/*.ipynb
    # not working due to https://github.com/tox-dev/tox/issues/1571


### PR DESCRIPTION
Fix `notebooks` testing configuration `env` warning: add the `test` extra to the `notebooks` testing environment so that the `pytest-env` plugin is present.

Fixes:
```
.tox/notebooks/lib/python3.12/site-packages/_pytest/config/__init__.py:1441
  PytestConfigWarning: Unknown config option: env

  self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/12969034501/job/36172649151?pr=72#step:12:1069