### PR TITLE
DOC: Use appropriate name for b-values kwarg in iterators

### DIFF
--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -35,12 +35,11 @@ def linear_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     ----------
     size : :obj:`int` or ``None``, optional
         Number of volumes in the dataset.
-        If ``None``, ``size`` will be inferred from the ``bvalues``
-        keyword argument.
-    bvalues : :obj:`list`, optional (keyword argument)
+        If ``None``, ``size`` will be inferred from the ``bvals`` keyword argument.
+    bvals : :obj:`list`, optional (keyword argument)
         List of b-values corresponding to all orientations of a DWI dataset.
         If ``size`` is provided, this argument will be ignored.
-        Otherwise, ``size`` will be inferred from the length of ``bvalues``.
+        Otherwise, ``size`` will be inferred from the length of ``bvals``.
 
     Yields
     ------
@@ -74,12 +73,11 @@ def random_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     ----------
     size : :obj:`int` or ``None``, optional
         Number of volumes in the dataset.
-        If ``None``, ``size`` will be inferred from the ``bvalues``
-        keyword argument.
-    bvalues : :obj:`list`, optional (keyword argument)
+        If ``None``, ``size`` will be inferred from the ``bvals`` keyword argument.
+    bvals : :obj:`list`, optional (keyword argument)
         List of b-values corresponding to all orientations of a DWI dataset.
         If ``size`` is provided, this argument will be ignored.
-        Otherwise, ``size`` will be inferred from the length of ``bvalues``.
+        Otherwise, ``size`` will be inferred from the length of ``bvals``.
     seed : :obj:`int`, :obj:`bool`, :obj:`str`, or ``None``, optional (keyword argument)
         If :obj:`int` or :obj:`str` or ``None``, initializes the seed of Python's random generator
         with the given value.
@@ -126,9 +124,9 @@ def bvalue_iterator(*_, **kwargs) -> Iterator[int]:
 
     Parameters
     ----------
-    bvalues : :obj:`list`
+    bvals : :obj:`list`
         List of b-values corresponding to all orientations of the dataset.
-        Please note that ``bvalues`` is a keyword argument and MUST be provided
+        Please note that ``bvals`` is a keyword argument and MUST be provided
         to generate the volume sequence.
 
     Yields
@@ -157,12 +155,11 @@ def centralsym_iterator(size: int | None = None, **kwargs) -> Iterator[int]:
     ----------
     size : :obj:`int` or ``None``, optional
         Number of volumes in the dataset.
-        If ``None``, ``size`` will be inferred from the ``bvalues``
-        keyword argument.
-    bvalues : :obj:`list`, optional (keyword argument)
+        If ``None``, ``size`` will be inferred from the ``bvals`` keyword argument.
+    bvals : :obj:`list`, optional (keyword argument)
         List of b-values corresponding to all orientations of the dataset.
         If ``size`` is provided, this argument will be ignored.
-        Otherwise, ``size`` will be inferred from the length of ``bvalues``.
+        Otherwise, ``size`` will be inferred from the length of ``bvals``.
 
     Yields
     ------


### PR DESCRIPTION
Use appropriate name for b-values kwarg in iterators: while the docstrings were documenting the `bvalues` keyword argument, the code was checking the presence of the `bvals` name. Use `bvals` in the docstrings.