### PR TITLE
STYLE: Increase consistency in data path across notebooks

### DIFF
--- a/docs/notebooks/bold_realignment.ipynb
+++ b/docs/notebooks/bold_realignment.ipynb
@@ -7,6 +7,7 @@
    "outputs": [],
    "source": [
     "import asyncio\n",
+    "from os import getenv\n",
     "from pathlib import Path\n",
     "from shutil import copy, move\n",
     "\n",
@@ -30,7 +31,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATA_PATH = Path(\"/data/datasets/\")\n",
+    "# Install test data from gin.g-node.org:\n",
+    "#   $ datalad install -g https://gin.g-node.org/nipreps-data/tests-nifreeze.git\n",
+    "# and point the environment variable TEST_DATA_HOME to the corresponding folder\n",
+    "DATA_PATH = Path(getenv(\"TEST_DATA_HOME\", str(Path.home() / \"nifreeze-tests\")))\n",
     "WORKDIR = Path.home() / \"tmp\" / \"nifreezedev\" / \"ismrm25\"\n",
     "WORKDIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",


### PR DESCRIPTION
Increase consistency in data path across notebooks: check if the `TEST_DATA_HOME` environment variable if set and use it if such is the case; otherwise, use `Path.home() / "nifreeze-tests"`.

This matches the convention used for the `dmri_covariance.ipynb` notebook.