### PR TITLE
FIX: Actually run notebooks on CI

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,0 +1,30 @@
+name: Run notebooks
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC
+
+jobs:
+  run-notebooks:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.12']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run notebooks with tox
+        run: tox -e notebooks

--- a/tools/run_notebooks.py
+++ b/tools/run_notebooks.py
@@ -24,7 +24,17 @@
 import glob
 import subprocess
 import sys
+from os import getenv
+from pathlib import Path
 
+# Download the data
+DATA_PATH = Path(getenv("TEST_DATA_HOME", str(Path.home() / "nifreeze-tests")))
+DATA_PATH.mkdir(parents=True, exist_ok=True)
+
+script_path = Path(__file__).resolve().parent / "../scripts/fetch_fmri_nb_openneuro_data.sh"
+subprocess.run(["bash", str(script_path), str(DATA_PATH)], check=True)
+
+# Find and run the notebooks
 notebooks = glob.glob("docs/notebooks/*.ipynb")
 # Make bold_realignment.ipynb Jupyter notebook an exception as it involves running a realignment
 # process for several DataLad datasets, which requires long running times.

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skip_missing_interpreters = true
 python =
   3.10: py310
   3.11: py311
-  3.12: py312, notebooks
+  3.12: py312
   3.13: py313
 
 [testenv]


### PR DESCRIPTION
Fix running notebooks:
- Notebooks were being supposedly run within the `test.yml` workflow. However, the fMRI BOLD notebook requires some data to be downloaded from OpenNeuro, and the data was not being downloaded.
- Run the data downloading script within the `notebooks` testing environment in `tox.ini`
- Run notebooks once every week through a cron job in a dedicated workflow file.
- Modify the Python versions being used in the CI `test.yml` file to avoid running the notebooks.