### PR TITLE
TST: Install `git-annex` for `datalad`

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install git-annex
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-annex
+
       - name: Install DataLad
         run: pip install datalad
 


### PR DESCRIPTION
Install `git-annex` for `datalad`.

Fixes:
```
install(error):
 /home/runner/work/nifreeze/nifreeze/nifreeze-tests/ds000005 (dataset)
 [No working git-annex installation of version >= 8.20200309.
 Visit http://handbook.datalad.org/r.html?install
 for instructions on how to install DataLad and git-annex.]
Error: Process completed with exit code 1.
```

raised for example in:
https://github.com/jhlegarreta/nifreeze/actions/runs/14812843818/job/41589689568#step:6:27