### PR TITLE
TST: Install `TeX` packages in notebook workflow

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install TeX Live
+        run: |
+          sudo apt-get update
+          sudo apt install texlive texlive-latex-extra texlive-fonts-recommended cm-super dvipng
+
       - name: Install git-annex
         run: |
           sudo apt-get update


### PR DESCRIPTION
Install the necessary `TeX` packages in the test CI so that `LaTeX` decoration in plots can be employed.

Fixes:
```
FAILED docs/notebooks/data_structures.ipynb::data_structures.ipynb -
 RuntimeError: Failed to process string with tex because latex could not be foun
```

and other related errors.

raised for example in:
https://github.com/jhlegarreta/nifreeze/actions/runs/14813656376/job/41591480555#step:9:844