### PR TITLE
TST: Download data from `G-Node` `GIN` in notebook testing GHA workflow

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -23,6 +23,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Download data file from G-Node GIN
+        run: |
+          DATA_PATH="${{ env.TEST_DATA_HOME || github.workspace }}/nifreeze-tests"
+          mkdir -p "$DATA_PATH"
+          curl -L -o "${DATA_PATH}/hcpdata.npz" https://gin.g-node.org/nipreps-data/tests-nifreeze/src/master/hcpdata.npz
+          echo "TEST_DATA_HOME"
+          ls -la ${{ env.TEST_DATA_HOME }}
+          echo "workspace"
+          ls -la ${{ github.workspace }}
+          echo "nifreeze-tests"
+          ls -la ${{ github.workspace }}/nifreeze-tests
+
       - name: Install TeX Live
         run: |
           sudo apt-get update
@@ -46,7 +58,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
 
-      - name: Download data
+      - name: Download data from OpenNeuro
         run: |
           DATA_PATH="${{ env.TEST_DATA_HOME || github.workspace }}/nifreeze-tests"
           mkdir -p "$DATA_PATH"


### PR DESCRIPTION
Download data from `G-Node` `GIN` in notebook testing GHA workflow.

Fixes:
```
/home/runner/work/nifreeze/nifreeze/docs/notebooks/dmri_covariance.ipynb

hcpdata = np.load(DATA_PATH/"hcpdata.npz")

FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/nifreeze-tests/hcpdata.npz'
```

raised for example in:
https://github.com/jhlegarreta/nifreeze/actions/runs/14814107025/job/41592479776#step:10:64