### PR TITLE
TST: Download dMRI covariance notebook data from OSF

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -41,10 +41,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Download data file from G-Node GIN
+      - name: Download data file from OSF
         run: |
           mkdir ${TEST_DATA_HOME}
-          curl -L -o "${TEST_DATA_HOME}/hcpdata.npz" https://gin.g-node.org/nipreps-data/tests-nifreeze/src/master/hcpdata.npz
+          pip install osfclient
+          osf -p 39k4x fetch hcpdata.npz "${TEST_DATA_HOME}/hcpdata.npz"
 
       - name: Install TeX Live
         run: |


### PR DESCRIPTION
Download dMRI covariance notebook data from OSF instead of using G-Node GIN: the latter is orders of magnitude slower, which is inconvenient to test the notebook.

The data has been previously uploaded to OSF.

Install the `osfclient` in order to effectively download the data.