### PR TITLE
TST: Pin `virtualenv` for benchmark environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ antsopt = [
 benchmark = [
     "asv",
     "pyperf",
-    "virtualenv",
+    "virtualenv==20.30",
 ]
 
 # Aliases


### PR DESCRIPTION
Pin `virtualenv` for benchmark environment: the latest `virtualenv` version (v20.31.0) drops the support for the `--wheel=bundle` argument, resulting in following error when running `asv` setup:

```
virtualenv: error: unrecognized arguments: --wheel=bundle
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/14895685075/job/41838083838#step:6:46

Solution proposed in the `asv` repository:
https://github.com/airspeed-velocity/asv/issues/1484#issuecomment-2853982396