### PR TITLE
TST: Do not remove fMRI notebook from list of discovered notebooks

### DIFF
--- a/tools/run_notebooks.py
+++ b/tools/run_notebooks.py
@@ -27,8 +27,5 @@ import sys
 
 # Find and run the notebooks
 notebooks = glob.glob("docs/notebooks/*.ipynb")
-# Make bold_realignment.ipynb Jupyter notebook an exception as it involves running a realignment
-# process for several DataLad datasets, which requires long running times.
-notebooks.remove("docs/notebooks/bold_realignment.ipynb")
 
 sys.exit(subprocess.call(["pytest", "--nbmake"] + notebooks))


### PR DESCRIPTION
Do not remove fMRI notebook from list of discovered notebooks: this will allow running the notebook at the time scheduled by the `notebooks.yml` GHA workflow file.