### PR TITLE
ENH: Re-allow "locking" of models with first fit

### DIFF
--- a/src/nifreeze/cli/run.py
+++ b/src/nifreeze/cli/run.py
@@ -69,9 +69,11 @@ def main(argv=None) -> None:
 
     prev_model: Estimator | None = None
     for _model in args.models:
+        single_fit = _model.lower().startswith("single")
         estimator: Estimator = Estimator(
-            _model,
+            _model.lower().replace("single", ""),
             prev=prev_model,
+            single_fit=single_fit,
         )
         prev_model = estimator
 


### PR DESCRIPTION
This allows having "frozen" models that are fit only once before entering the leave-one-out loop.

These models use all the data in the fitting and then return always the same "prediction".

This feature was lost with the refactor of the estimator. By moving it into the models, we can use them in a more flexible way.