### PR TITLE
FIX: Fix FD plot function call in BOLD fMRI realignment notebook

### DIFF
--- a/docs/notebooks/bold_realignment.ipynb
+++ b/docs/notebooks/bold_realignment.ipynb
@@ -166,19 +166,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
     "from nifreeze.viz.motion_viz import plot_framewise_displacement\n",
     "\n",
     "\n",
@@ -264,10 +258,9 @@
     "    )\n",
     "\n",
     "    # Plot the framewise displacement on the first axis\n",
+    "    fd = pd.DataFrame({\"afni\": afni_fd, \"nifreeze\": nifreeze_fd})\n",
     "    fd_axis = axes[0]\n",
-    "    _ = plot_framewise_displacement(\n",
-    "        afni_fd, nifreeze_fd, \"AFNI 3dVolreg FD\", \"nifreeze FD\", ax=fd_axis\n",
-    "    )\n",
+    "    _ = plot_framewise_displacement(fd, [\"AFNI 3dVolreg FD\", \"nifreeze FD\"], ax=fd_axis)\n",
     "\n",
     "    # Set labels for profile plots if not provided\n",
     "    if labels is None or isinstance(labels, str):\n",


### PR DESCRIPTION
Fix FD plot function call in BOLD fMRI realignment notebook: provide the framewise displacement data as a `pandas` `DataFrame` and group the labels for the legend into a list.

Left behind in commit 2d95cbb.

Take advantage of the commit to transfer a lonely `import` statement to the immediately subsequent cell where the actual plot function is called for the sake of compactness and consistency.