### PR TITLE
STY: Reorder notebook GHA workflow file steps for improved logic

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -41,12 +41,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Download data file from OSF
-        run: |
-          mkdir ${TEST_DATA_HOME}
-          pip install osfclient
-          osf -p 39k4x fetch hcpdata.npz "${TEST_DATA_HOME}/hcpdata.npz"
-
       - name: Install TeX Live
         run: |
           sudo apt-get update
@@ -65,14 +59,20 @@ jobs:
       - name: Install DataLad
         run: pip install datalad
 
+      - name: Download data from OpenNeuro
+        run: |
+          ${{ github.workspace }}/scripts/fetch_fmri_nb_openneuro_data.sh "${TEST_DATA_HOME}"
+
+      - name: Download data from OSF
+        run: |
+          mkdir ${TEST_DATA_HOME}
+          pip install osfclient
+          osf -p 39k4x fetch hcpdata.npz "${TEST_DATA_HOME}/hcpdata.npz"
+
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
           pip install tox
-
-      - name: Download data from OpenNeuro
-        run: |
-          ${{ github.workspace }}/scripts/fetch_fmri_nb_openneuro_data.sh "${TEST_DATA_HOME}"
 
       - name: Run notebooks with tox
         run: tox -e notebooks


### PR DESCRIPTION
Reorder notebook GHA workflow file steps for improved logic:
1. Set up the action.
2. Install the necessary libraries.
3. Download the data.
4. Install `tox` to be able to run the notebooks.
5. Run the notebooks.

Take advantage of the commit to improve the name of the OSF data download step.