### PR TITLE
TST: Avoid attempting to create test data directory in notebook GHA

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -86,13 +86,15 @@ jobs:
       - name: Install DataLad
         run: pip install datalad
 
+      - name: Create test data directory
+        run: mkdir ${TEST_DATA_HOME}
+
       - name: Download data from OpenNeuro
         run: |
           ${{ github.workspace }}/scripts/fetch_fmri_nb_openneuro_data.sh "${TEST_DATA_HOME}"
 
       - name: Download data from OSF
         run: |
-          mkdir ${TEST_DATA_HOME}
           pip install osfclient
           osf -p 39k4x fetch hcpdata.npz "${TEST_DATA_HOME}/hcpdata.npz"
 


### PR DESCRIPTION
Avoid attempting to create test data directory in notebook GHA workflow file: create testing data directory before starting to download data.

The step where the data from `OpenNeuro` was being downloaded was effectively creating the test data directory and, thus, attempting to create the directory was failinng in the next step, where the data from OSF was bing downloaded, and which included creating the directory.

Fixes:
```
Run mkdir ${TEST_DATA_HOME}
(...)
mkdir: cannot create directory ‘/home/runner/nifreeze-tests/’: File exists
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/15097105297/job/42433228274?pr=117#step:11:19

Inadvertently introduced in commit c170c40.