### PR TITLE
MAINT: Increase notebook timeout value

### DIFF
--- a/tools/run_notebooks.py
+++ b/tools/run_notebooks.py
@@ -28,4 +28,4 @@ import sys
 # Find and run the notebooks
 notebooks = glob.glob("docs/notebooks/*.ipynb")
 
-sys.exit(subprocess.call(["pytest", "--nbmake"] + notebooks))
+sys.exit(subprocess.call(["pytest", "--nbmake", "--nbmake-timeout=3600"] + notebooks))


### PR DESCRIPTION
Increase notebook timeout value: set it to 3600 s (60 minutes; the default value is 300 s).

Fixes:
```
__ /home/runner/work/nifreeze/nifreeze/docs/notebooks/bold_realignment.ipynb ___
A cell timed out while it was being executed, after 300 seconds.
The message was: Cell execution timed out.
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/15102456036/job/42445432169#step:15:43