### PR TITLE
DOC: Remove "Accepted" note in citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,5 +20,5 @@ conference:
   place: "Honolulu, HI USA"
   date: 2025-05-10
 type: conference-paper
-abstract: "Accepted. Program #3252"
+abstract: "Program #3252"
 url: "https://osf.io/preprints/psyarxiv/gfny9_v2"


### PR DESCRIPTION
Remove "Accepted" note in citation file: the work was presented on May 14 2025.