### PR TITLE
STY: Fix miscellaneous static check failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
+    "attrs",
     "dipy>=1.5.0",
     "joblib",
     "nipype>= 1.5.1,<2.0",
@@ -80,6 +81,7 @@ types = [
   "pandas-stubs",
   "types-setuptools",
   "scipy-stubs",
+  "types-attrs",
   "types-PyYAML",
   "types-tqdm",
   "pytest",

--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any, Generic
 
-import attr
+import attrs
 import h5py
 import nibabel as nb
 import numpy as np
@@ -55,7 +55,7 @@ def _cmp(lh: Any, rh: Any) -> bool:
     return lh == rh
 
 
-@attr.s(slots=True)
+@attrs.define(slots=True)
 class BaseDataset(Generic[Unpack[Ts]]):
     """
     Base dataset representation structure.
@@ -72,18 +72,18 @@ class BaseDataset(Generic[Unpack[Ts]]):
 
     """
 
-    dataobj: np.ndarray = attr.ib(default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp))
+    dataobj: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A :obj:`~numpy.ndarray` object for the data array."""
-    affine: np.ndarray = attr.ib(default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp))
+    affine: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """Best affine for RAS-to-voxel conversion of coordinates (NIfTI header)."""
-    brainmask: np.ndarray = attr.ib(default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp))
+    brainmask: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A boolean ndarray object containing a corresponding brainmask."""
-    motion_affines: np.ndarray = attr.ib(default=None, eq=attr.cmp_using(eq=_cmp))
+    motion_affines: np.ndarray = attrs.field(default=None, eq=attrs.cmp_using(eq=_cmp))
     """List of :obj:`~nitransforms.linear.Affine` realigning the dataset."""
-    datahdr: SpatialHeader = attr.ib(default=None)
+    datahdr: SpatialHeader = attrs.field(default=None)
     """A :obj:`~nibabel.spatialimages.SpatialHeader` header corresponding to the data."""
 
-    _filepath = attr.ib(
+    _filepath: Path = attrs.field(
         factory=lambda: Path(mkdtemp()) / "hmxfms_cache.h5",
         repr=False,
         eq=False,
@@ -220,7 +220,7 @@ class BaseDataset(Generic[Unpack[Ts]]):
             out_file.attrs["Version"] = np.uint16(1)
             root = out_file.create_group("/0")
             root.attrs["Type"] = "base dataset"
-            for f in attr.fields(self.__class__):
+            for f in attrs.fields(self.__class__):
                 if f.name.startswith("_"):
                     continue
 

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Any
 from warnings import warn
 
-import attr
+import attrs
 import h5py
 import nibabel as nb
 import numpy as np
@@ -66,15 +66,15 @@ DTI_MIN_ORIENTATIONS = 6
 """Minimum number of nonzero b-values in a DWI dataset."""
 
 
-@attr.s(slots=True)
+@attrs.define(slots=True)
 class DWI(BaseDataset[np.ndarray | None]):
     """Data representation structure for dMRI data."""
 
-    bzero = attr.ib(default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp))
+    bzero: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A *b=0* reference map, preferably obtained by some smart averaging."""
-    gradients = attr.ib(default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp))
+    gradients: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A 2D numpy array of the gradient table (4xN)."""
-    eddy_xfms = attr.ib(default=None)
+    eddy_xfms: list = attrs.field(default=None)
     """List of transforms to correct for estimated eddy current distortions."""
 
     def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray | None]:

--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Union
 
-import attr
+import attrs
 import h5py
 import numpy as np
 from nibabel.spatialimages import SpatialImage
@@ -37,15 +37,15 @@ from nifreeze.data.base import BaseDataset, _cmp, _data_repr
 from nifreeze.utils.ndimage import load_api
 
 
-@attr.s(slots=True)
+@attrs.define(slots=True)
 class PET(BaseDataset[np.ndarray | None]):
     """Data representation structure for PET data."""
 
-    frame_time: np.ndarray | None = attr.ib(
-        default=None, repr=_data_repr, eq=attr.cmp_using(eq=_cmp)
+    frame_time: np.ndarray | None = attrs.field(
+        default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp)
     )
     """A (N,) numpy array specifying the midpoint timing of each sample or frame."""
-    total_duration: float | None = attr.ib(default=None, repr=True)
+    total_duration: float | None = attrs.field(default=None, repr=True)
     """A float representing the total duration of the dataset."""
 
     def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray | None]:


### PR DESCRIPTION
Fix miscellaneous static check failures: transition to the more modern `attrs` API in lieu of `attr`:
- Install the `attrbs` package and the missing type stubs for the `attrs` library.
- Adapt the corresponding properties: use `@attrs.define` instead of `@attr.s`, and `attrs.field` instead of `attr.ib`.
- Add missing annotations for `data.base.BaseDataset` and `data.dmri.DWI` attributes.

Fixes:
```
Cannot find implementation or library stub for module named "attr"
```

and
```
src/nifreeze/data/base.py:32: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/nifreeze/data/pet.py:30: error: Cannot find implementation or library stub for module named "attrs"  [import-not-found]
src/nifreeze/data/pet.py:170: error: Unexpected keyword argument "dataobj" for "PET"  [call-arg]
.tox/typecheck/lib/python3.12/site-packages/mypy/typeshed/stdlib/builtins.pyi:110: note: "PET" defined here
src/nifreeze/data/pet.py:170: error: Unexpected keyword argument "affine" for "PET"  [call-arg]
.tox/typecheck/lib/python3.12/site-packages/mypy/typeshed/stdlib/builtins.pyi:110: note: "PET" defined here
```

and
```
rc/nifreeze/data/base.py:86: error: Need type annotation for "_filepath"  [var-annotated]
src/nifreeze/data/dmri.py:73: error: Need type annotation for "bzero"  [var-annotated]
src/nifreeze/data/dmri.py:75: error: Need type annotation for "gradients"  [var-annotated]
```

and other similar errors raised for exmaple at:
https://github.com/nipreps/nifreeze/actions/runs/15162795559/job/42632741133#step:8:33
https://github.com/nipreps/nifreeze/actions/runs/15174700127/job/42672566195?pr=133#step:8:33

Documentation:
https://www.attrs.org/en/stable/index.html