### PR TITLE
FIX: Treatment of ``n_jobs`` by estimator

### DIFF
--- a/src/nifreeze/cli/parser.py
+++ b/src/nifreeze/cli/parser.py
@@ -97,7 +97,10 @@ def build_parser() -> ArgumentParser:
         help="Maximum number of threads an individual process may use.",
     )
     parser.add_argument(
+        "-J",
+        "--n-jobs",
         "--njobs",
+        dest="n_jobs",
         action="store",
         type=int,
         default=None,

--- a/src/nifreeze/cli/run.py
+++ b/src/nifreeze/cli/run.py
@@ -79,7 +79,7 @@ def main(argv=None) -> None:
         dataset,
         align_kwargs=args.align_config,
         omp_nthreads=args.nthreads,
-        njobs=args.njobs,
+        n_jobs=args.n_jobs,
         seed=args.seed,
     )
 

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -106,7 +106,7 @@ class Estimator:
             if isinstance(self._prev, Filter):
                 dataset = result  # type: ignore[assignment]
 
-        n_jobs = kwargs.pop("n_jobs", None) or min(cpu_count(), 8)
+        n_jobs = kwargs.pop("n_jobs", None) or min(cpu_count() or 1, 8)
 
         # Prepare iterator
         iterfunc = getattr(iterators, f"{self._strategy}_iterator")

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -106,7 +106,7 @@ class Estimator:
             if isinstance(self._prev, Filter):
                 dataset = result  # type: ignore[assignment]
 
-        n_jobs = kwargs.pop("n_jobs", None) or kwargs.pop("njobs", None) or min(cpu_count(), 8)
+        n_jobs = kwargs.pop("n_jobs", None) or min(cpu_count(), 8)
 
         # Prepare iterator
         iterfunc = getattr(iterators, f"{self._strategy}_iterator")

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 
+from os import cpu_count
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TypeVar
@@ -105,7 +106,7 @@ class Estimator:
             if isinstance(self._prev, Filter):
                 dataset = result  # type: ignore[assignment]
 
-        n_jobs = kwargs.get("n_jobs", None)
+        n_jobs = kwargs.pop("n_jobs", None) or kwargs.pop("njobs", None) or min(cpu_count(), 8)
 
         # Prepare iterator
         iterfunc = getattr(iterators, f"{self._strategy}_iterator")

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -113,7 +113,7 @@ def test_parser(tmp_path, datadir):
             "trivial",
             "--nthreads",
             "1",
-            "--njobs",
+            "--n-jobs",
             "1",
             "--seed",
             "1234",
@@ -123,5 +123,5 @@ def test_parser(tmp_path, datadir):
     )
 
     assert args.input_file == input_file
-    assert args.njobs == 1
+    assert args.n_jobs == 1
     assert args.output_dir == tmp_path


### PR DESCRIPTION
The CLI passes ``njobs``, while DIPY uses ``n_jobs``. This PR unifies the variable name.