### PR TITLE
MNT: Add dependencies to author update script

### DIFF
--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "click",
+#     "fuzzywuzzy",
+# ]
+# ///
 """Update and sort the creators list of the zenodo record."""
 
 import json


### PR DESCRIPTION
Add dependencies to author update script as a script metadata comment block so that tools like `uv` can create an isolated environment without a full project setup.