### PR TITLE
STY: Add license header to author update script

### DIFF
--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -1,4 +1,25 @@
-#!/usr/bin/env python3
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
 """Update and sort the creators list of the zenodo record."""
 
 import json


### PR DESCRIPTION
Add license header to author update script.

Take advantage of the commit to remove the Python interpreter shebang line for the sake of consistency across the package and current conventions across the NiPreps projects.