### PR TITLE
MNT: Configure `coverage` for parallel execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ filterwarnings = [
 
 [tool.coverage.run]
 branch = true
+parallel = true
 concurrency = ['multiprocessing']
 omit = [
     '*/tests/*',


### PR DESCRIPTION
Configure `coverage` for parallel execution: set `coverage`'s `parallel` flag to `true` so that when reporting coverage tests running in parallel (achieved using `pytest-xdist`, and enabled for `coverage` using the `multiprocessing` concurrency) do not fall into race conditions and write to different `.coverage.` files. These files need to be assembled later to provide aggregated statistics.