### PR TITLE
ENH: Add GQI to available models

### DIFF
--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -66,7 +66,7 @@ class ModelFactory:
 
             return AverageDWIModel(kwargs.pop("dataset"), **kwargs)
 
-        if model.lower() in ("dti", "dki", "pet"):
+        if model.lower() in ("gqi", "dti", "dki", "pet"):
             from importlib import import_module
 
             dmrimod = import_module("nifreeze.model.dmri")

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -308,6 +308,17 @@ class DKIModel(BaseDWIModel):
     _model_class = "dipy.reconst.dki.DiffusionKurtosisModel"
 
 
+class GQIModel(BaseDWIModel):
+    """A wrapper of :obj:`dipy.reconst.gqi.GeneralizedQSamplingModel`."""
+
+    _modelargs = (
+        "method",
+        "sampling_length",
+        "normalize_peaks",
+    )
+    _model_class = "dipy.reconst.gqi.GeneralizedQSamplingModel"
+
+
 class GPModel(BaseDWIModel):
     """A wrapper of :obj:`~nifreeze.model.dipy.GaussianProcessModel`."""
 

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -123,7 +123,7 @@ class BaseDWIModel(BaseModel):
 
         # DIPY models (or one with a fully-compliant interface)
         model_str = getattr(self, "_model_class", "")
-        if "dipy" in model_str:
+        if "dipy" in model_str or "GeneralizedQSamplingModel" in model_str:
             gtab = gradient_table_from_bvals_bvecs(gtab[-1, :], gtab[:-1, :].T)
 
         if model_str:
@@ -187,7 +187,8 @@ class BaseDWIModel(BaseModel):
 
         gradient = self._dataset.gradients[:, index]
 
-        if "dipy" in getattr(self, "_model_class", ""):
+        model_str = getattr(self, "_model_class", "")
+        if "dipy" in model_str or "GeneralizedQSamplingModel" in model_str:
             gradient = gradient_table_from_bvals_bvecs(
                 gradient[np.newaxis, -1], gradient[np.newaxis, :-1]
             )
@@ -316,7 +317,7 @@ class GQIModel(BaseDWIModel):
         "sampling_length",
         "normalize_peaks",
     )
-    _model_class = "dipy.reconst.gqi.GeneralizedQSamplingModel"
+    _model_class = "nifreeze.model.gqi.GeneralizedQSamplingModel"
 
 
 class GPModel(BaseDWIModel):

--- a/src/nifreeze/model/gqi.py
+++ b/src/nifreeze/model/gqi.py
@@ -1,0 +1,440 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+# STATEMENT OF CHANGES:
+# This file was created from the original `dipy.reconst.gqi` module
+# in DIPY.
+# We will be piloting the use of this module in NiFreeze to later
+# consider its inclusion in DIPY (https://github.com/dipy/dipy/pull/3553).
+# The original module is licensed under the BSD-3-Clause, which is reproduced
+# below:
+#
+# ORIGINAL LICENSE:
+# Unless otherwise specified by LICENSE.txt files in individual
+# directories, or within individual files or functions, all code is:
+#
+# Copyright (c) 2008-2025, dipy developers
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#
+#     * Neither the name of the dipy developers nor the names of any
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Classes and functions for generalized q-sampling"""
+
+import warnings
+
+import numpy as np
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.reconst.base import ReconstFit, ReconstModel
+from dipy.testing.decorators import warning_for_keywords
+
+INVERSE_LAMBDA = 1e-6
+DEFAULT_SPHERE_RECURSION_LEVEL = 5
+
+
+class GeneralizedQSamplingModel(ReconstModel):
+    @warning_for_keywords()
+    def __init__(
+        self,
+        gtab,
+        *,
+        method="standard",
+        sampling_length=1.2,
+        normalize_peaks=False,
+        sphere=None,
+    ):
+        r"""Generalized Q-Sampling Imaging.
+
+        See :footcite:t:`Yeh2010` for further details about the model.
+
+        This model has the same assumptions as the DSI method i.e. Cartesian
+        grid sampling in q-space and fast gradient switching.
+
+        Implements equations 2.14 from :footcite:p:`Garyfallidis2012b` for
+        standard GQI and equation 2.16 from :footcite:p:`Garyfallidis2012b` for
+        GQI2. You can think of GQI2 as an analytical solution of the DSI ODF.
+
+        Parameters
+        ----------
+        gtab : object,
+            GradientTable
+        method : str, optional
+            'standard' or 'gqi2'
+        sampling_length : float, optional
+            diffusion sampling length (lambda in eq. 2.14 and 2.16)
+        normalize_peaks : bool, optional
+            True to normalize peaks.
+        sphere : :obj:`~dipy.core.sphere.Sphere`, optional
+            A sphere object, must be the same used for calculating the ODFs.
+            If not provided, a default sphere will be created.
+
+        Notes
+        -----
+        As of version 0.9, range of the sampling length in GQI2 has changed
+        to match the same scale used in the 'standard' method
+        :footcite:t:`Yeh2010`. This means that the value of `sampling_length`
+        should be approximately 1 - 1.3 (see :footcite:t:`Yeh2010`, pg. 1628).
+
+        References
+        ----------
+        .. footbibliography::
+
+        Examples
+        --------
+        Here we create an example where we provide the data, a gradient table
+        and a reconstruction sphere and calculate the ODF for the first
+        voxel in the data.
+
+        >>> from dipy.data import dsi_voxels
+        >>> data, gtab = dsi_voxels()
+        >>> from dipy.core.subdivide_octahedron import create_unit_sphere
+        >>> sphere = create_unit_sphere(recursion_level=5)
+        >>> from dipy.reconst.gqi import GeneralizedQSamplingModel
+        >>> gq = GeneralizedQSamplingModel(gtab, method='standard', sampling_length=1.1)
+        >>> voxel_signal = data[0, 0, 0]
+        >>> odf = gq.fit(voxel_signal).odf(sphere)
+
+        See Also
+        --------
+        dipy.reconst.dsi.DiffusionSpectrumModel
+
+        """
+        ReconstModel.__init__(self, gtab)
+        self.method = method
+        self.Lambda = sampling_length
+        self.normalize_peaks = normalize_peaks
+        self.gtab = gtab
+        self.sphere = (
+            create_unit_sphere(recursion_level=DEFAULT_SPHERE_RECURSION_LEVEL)
+            if sphere is None
+            else sphere
+        )
+
+        # The gQI vector has shape (n_vertices, n_orientations)
+        self.kernel = gqi_kernel(
+            self.gtab,
+            self.Lambda,
+            self.sphere,
+            method=self.method,
+        ).T
+
+    def fit(self, data, **kwargs):
+        return GeneralizedQSamplingFit(self, data)
+
+    def predict(self, odf, *, S0=None):
+        """
+        Predict a signal for this GeneralizedQSamplingModel instance given parameters.
+
+        Parameters
+        ----------
+        odf : ndarray
+            Map of ODFs.
+        gtab : ndarray
+            Orientations where signal will be simulated
+        sphere : :obj:`~dipy.core.sphere.Sphere`
+            A sphere object, must be the same used for calculating the ODFs.
+
+        """
+
+        return prediction_kernel(self.gtab, self.Lambda, self.sphere, method=self.method)
+
+
+class GeneralizedQSamplingFit(ReconstFit):
+    def __init__(self, model, data):
+        """Calculates PDF and ODF for a single voxel
+
+        Parameters
+        ----------
+        model : object,
+            DiffusionSpectrumModel
+        data : 1d ndarray,
+            signal values
+
+        """
+        ReconstFit.__init__(self, model, data)
+        self._gfa = None
+        self.npeaks = 5
+        self._peak_values = None
+        self._peak_indices = None
+        self._qa = None
+        self.odf_fit = None
+
+    def fit(self, data, *, mask=None):
+        if self.odf_fit is None:
+            self.odf_fit = self.odf(data)
+        return self
+
+    def odf(self):
+        """Calculates the discrete ODF for a given discrete sphere."""
+        return self.model.kernel @ self.data
+
+    def predict(self, gtab, *, S0=None):
+        """Predict using the fit model."""
+        K = (
+            prediction_kernel(
+                gtab,
+                self.model.Lambda,
+                self.model.sphere,
+            )
+            @ self.model.kernel
+        )
+
+        return (K @ self.data.T).T
+
+
+def gqi_kernel(gtab, param_lambda, sphere, method="standard"):
+    # 0.01506 = 6*D where D is the free water diffusion coefficient
+    # l_values sqrt(6 D tau) D free water diffusion coefficient and
+    # tau included in the b-value
+    scaling = np.sqrt(gtab.bvals * 0.01506)
+    b_vector = gtab.bvecs * scaling[:, None]
+
+    if method == "gqi2":
+        H = squared_radial_component
+        return np.real(H(np.dot(b_vector, sphere.vertices.T) * param_lambda))
+    elif method != "standard":
+        warnings.warn(
+            f'GQI model "{method}" unknown, falling back to "standard".',
+            stacklevel=1,
+        )
+    return np.real(np.sinc(np.dot(b_vector, sphere.vertices.T) * param_lambda / np.pi))
+
+
+def prediction_kernel(gtab, param_lambda, sphere, method="standard"):
+    r"""
+    Predict a signal given the ODF.
+
+    Parameters
+    ----------
+    odf : ndarray
+        ODF parameters.
+
+    gtab : GradientTable
+        The gradient table for this prediction
+
+    Notes
+    -----
+    The predicted signal is given by:
+
+    .. math::
+
+        S(\theta, b) = K_{ii}^{-1} \cdot ODF
+
+    where $K_{ii}^{-1}$, is the inverse of the GQI kernels for the direction(s) $ii$
+    given by ``gtab``.
+
+    """
+    # K.shape = (n_gradients, n_vertices)
+    K = gqi_kernel(gtab, param_lambda, sphere, method=method)
+    GtG = K @ K.T
+    identity = np.eye(GtG.shape[0])
+    return np.linalg.inv(GtG + INVERSE_LAMBDA * identity) @ K
+
+
+@warning_for_keywords()
+def normalize_qa(qa, *, max_qa=None):
+    """Normalize quantitative anisotropy.
+
+    Used mostly with GQI rather than GQI2.
+
+    Parameters
+    ----------
+    qa : array, shape (X, Y, Z, N)
+        where N is the maximum number of peaks stored
+    max_qa : float,
+        maximum qa value. Usually found in the CSF (corticospinal fluid).
+
+    Returns
+    -------
+    nqa : array, shape (x, Y, Z, N)
+        normalized quantitative anisotropy
+
+    Notes
+    -----
+    Normalized quantitative anisotropy has the very useful property
+    to be very small near gray matter and background areas. Therefore,
+    it can be used to mask out white matter areas.
+
+    """
+    if max_qa is None:
+        return qa / qa.max()
+    return qa / max_qa
+
+
+@warning_for_keywords()
+def squared_radial_component(x, *, tol=0.01):
+    """Part of the GQI2 integral
+
+    Eq.8 in the referenced paper by :footcite:t:`Yeh2010`.
+
+    References
+    ----------
+    .. footbibliography::
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = (2 * x * np.cos(x) + (x * x - 2) * np.sin(x)) / (x**3)
+    x_near_zero = (x < tol) & (x > -tol)
+    return np.where(x_near_zero, 1.0 / 3, result)
+
+
+@warning_for_keywords()
+def npa(self, odf, *, width=5):
+    """non-parametric anisotropy
+
+    Nimmo-Smith et al.  ISMRM 2011
+    """
+    # odf = self.odf(s)
+    t0, t1, t2 = triple_odf_maxima(self.odf_vertices, odf, width)
+    psi0 = t0[1] ** 2
+    psi1 = t1[1] ** 2
+    psi2 = t2[1] ** 2
+    npa = np.sqrt((psi0 - psi1) ** 2 + (psi1 - psi2) ** 2 + (psi2 - psi0) ** 2) / np.sqrt(
+        2 * (psi0**2 + psi1**2 + psi2**2)
+    )
+    # print 'tom >>>> ',t0,t1,t2,npa
+
+    return t0, t1, t2, npa
+
+
+@warning_for_keywords()
+def equatorial_zone_vertices(vertices, pole, *, width=5):
+    """
+    finds the 'vertices' in the equatorial zone conjugate
+    to 'pole' with width half 'width' degrees
+    """
+    return [
+        i
+        for i, v in enumerate(vertices)
+        if np.abs(np.dot(v, pole)) < np.abs(np.sin(np.pi * width / 180))
+    ]
+
+
+@warning_for_keywords()
+def polar_zone_vertices(vertices, pole, *, width=5):
+    """
+    finds the 'vertices' in the equatorial band around
+    the 'pole' of radius 'width' degrees
+    """
+    return [
+        i
+        for i, v in enumerate(vertices)
+        if np.abs(np.dot(v, pole)) > np.abs(np.cos(np.pi * width / 180))
+    ]
+
+
+def upper_hemi_map(v):
+    """
+    maps a 3-vector into the z-upper hemisphere
+    """
+    return np.sign(v[2]) * v
+
+
+def equatorial_maximum(vertices, odf, pole, width):
+    eqvert = equatorial_zone_vertices(vertices, pole, width)
+    # need to test for whether eqvert is empty or not
+    if len(eqvert) == 0:
+        print(f"empty equatorial band at {np.array_str(pole)}  pole with width {width:f}")
+        return None, None
+    eqvals = [odf[i] for i in eqvert]
+    eqargmax = np.argmax(eqvals)
+    eqvertmax = eqvert[eqargmax]
+    eqvalmax = eqvals[eqargmax]
+
+    return eqvertmax, eqvalmax
+
+
+def patch_vertices(vertices, pole, width):
+    """
+    find 'vertices' within the cone of 'width' degrees around 'pole'
+    """
+    return [
+        i
+        for i, v in enumerate(vertices)
+        if np.abs(np.dot(v, pole)) > np.abs(np.cos(np.pi * width / 180))
+    ]
+
+
+def patch_maximum(vertices, odf, pole, width):
+    eqvert = patch_vertices(vertices, pole, width)
+    # need to test for whether eqvert is empty or not
+    if len(eqvert) == 0:
+        print(f"empty cone around pole {np.array_str(pole)} with with width {width:f}")
+        return np.Null, np.Null
+    eqvals = [odf[i] for i in eqvert]
+    eqargmax = np.argmax(eqvals)
+    eqvertmax = eqvert[eqargmax]
+    eqvalmax = eqvals[eqargmax]
+    return eqvertmax, eqvalmax
+
+
+def odf_sum(odf):
+    return np.sum(odf)
+
+
+def patch_sum(vertices, odf, pole, width):
+    eqvert = patch_vertices(vertices, pole, width)
+    # need to test for whether eqvert is empty or not
+    if len(eqvert) == 0:
+        print(f"empty cone around pole {np.array_str(pole)} with with width {width:f}")
+        return np.Null
+    return np.sum([odf[i] for i in eqvert])
+
+
+def triple_odf_maxima(vertices, odf, width):
+    indmax1 = np.argmax([odf[i] for i, v in enumerate(vertices)])
+    odfmax1 = odf[indmax1]
+    pole = vertices[indmax1]
+    eqvert = equatorial_zone_vertices(vertices, pole, width)
+    indmax2, odfmax2 = equatorial_maximum(vertices, odf, pole, width)
+    indmax3 = eqvert[np.argmin([np.abs(np.dot(vertices[indmax2], vertices[p])) for p in eqvert])]
+    odfmax3 = odf[indmax3]
+    """
+    cross12 = np.cross(vertices[indmax1],vertices[indmax2])
+    cross12 = cross12/np.sqrt(np.sum(cross12**2))
+    indmax3, odfmax3 = patch_maximum(vertices, odf, cross12, 2*width)
+    """
+    return [(indmax1, odfmax1), (indmax2, odfmax2), (indmax3, odfmax3)]

--- a/src/nifreeze/model/gqi.py
+++ b/src/nifreeze/model/gqi.py
@@ -69,14 +69,12 @@ import warnings
 import numpy as np
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.reconst.base import ReconstFit, ReconstModel
-from dipy.testing.decorators import warning_for_keywords
 
 INVERSE_LAMBDA = 1e-6
 DEFAULT_SPHERE_RECURSION_LEVEL = 5
 
 
 class GeneralizedQSamplingModel(ReconstModel):
-    @warning_for_keywords()
     def __init__(
         self,
         gtab,
@@ -86,62 +84,7 @@ class GeneralizedQSamplingModel(ReconstModel):
         normalize_peaks=False,
         sphere=None,
     ):
-        r"""Generalized Q-Sampling Imaging.
-
-        See :footcite:t:`Yeh2010` for further details about the model.
-
-        This model has the same assumptions as the DSI method i.e. Cartesian
-        grid sampling in q-space and fast gradient switching.
-
-        Implements equations 2.14 from :footcite:p:`Garyfallidis2012b` for
-        standard GQI and equation 2.16 from :footcite:p:`Garyfallidis2012b` for
-        GQI2. You can think of GQI2 as an analytical solution of the DSI ODF.
-
-        Parameters
-        ----------
-        gtab : object,
-            GradientTable
-        method : str, optional
-            'standard' or 'gqi2'
-        sampling_length : float, optional
-            diffusion sampling length (lambda in eq. 2.14 and 2.16)
-        normalize_peaks : bool, optional
-            True to normalize peaks.
-        sphere : :obj:`~dipy.core.sphere.Sphere`, optional
-            A sphere object, must be the same used for calculating the ODFs.
-            If not provided, a default sphere will be created.
-
-        Notes
-        -----
-        As of version 0.9, range of the sampling length in GQI2 has changed
-        to match the same scale used in the 'standard' method
-        :footcite:t:`Yeh2010`. This means that the value of `sampling_length`
-        should be approximately 1 - 1.3 (see :footcite:t:`Yeh2010`, pg. 1628).
-
-        References
-        ----------
-        .. footbibliography::
-
-        Examples
-        --------
-        Here we create an example where we provide the data, a gradient table
-        and a reconstruction sphere and calculate the ODF for the first
-        voxel in the data.
-
-        >>> from dipy.data import dsi_voxels
-        >>> data, gtab = dsi_voxels()
-        >>> from dipy.core.subdivide_octahedron import create_unit_sphere
-        >>> sphere = create_unit_sphere(recursion_level=5)
-        >>> from dipy.reconst.gqi import GeneralizedQSamplingModel
-        >>> gq = GeneralizedQSamplingModel(gtab, method='standard', sampling_length=1.1)
-        >>> voxel_signal = data[0, 0, 0]
-        >>> odf = gq.fit(voxel_signal).odf(sphere)
-
-        See Also
-        --------
-        dipy.reconst.dsi.DiffusionSpectrumModel
-
-        """
+        """Generalized Q-Sampling Imaging."""
         ReconstModel.__init__(self, gtab)
         self.method = method
         self.Lambda = sampling_length
@@ -274,7 +217,6 @@ def prediction_kernel(gtab, param_lambda, sphere, method="standard"):
     return np.linalg.inv(GtG + INVERSE_LAMBDA * identity) @ K
 
 
-@warning_for_keywords()
 def normalize_qa(qa, *, max_qa=None):
     """Normalize quantitative anisotropy.
 
@@ -304,16 +246,8 @@ def normalize_qa(qa, *, max_qa=None):
     return qa / max_qa
 
 
-@warning_for_keywords()
 def squared_radial_component(x, *, tol=0.01):
-    """Part of the GQI2 integral
-
-    Eq.8 in the referenced paper by :footcite:t:`Yeh2010`.
-
-    References
-    ----------
-    .. footbibliography::
-    """
+    """Part of the GQI2 integral."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         result = (2 * x * np.cos(x) + (x * x - 2) * np.sin(x)) / (x**3)
@@ -321,7 +255,6 @@ def squared_radial_component(x, *, tol=0.01):
     return np.where(x_near_zero, 1.0 / 3, result)
 
 
-@warning_for_keywords()
 def npa(self, odf, *, width=5):
     """non-parametric anisotropy
 
@@ -340,7 +273,6 @@ def npa(self, odf, *, width=5):
     return t0, t1, t2, npa
 
 
-@warning_for_keywords()
 def equatorial_zone_vertices(vertices, pole, *, width=5):
     """
     finds the 'vertices' in the equatorial zone conjugate
@@ -353,7 +285,6 @@ def equatorial_zone_vertices(vertices, pole, *, width=5):
     ]
 
 
-@warning_for_keywords()
 def polar_zone_vertices(vertices, pole, *, width=5):
     """
     finds the 'vertices' in the equatorial band around


### PR DESCRIPTION
Enables Generalized Q-Imaging to the portfolio of DIPY supported models.

I'm hitting the issue that this model does not have a `predict()` implementation (cc/ @yasseraleman).

```
NotImplementedError: This model does not have prediction implemented yet
```

@arokem, would it be very hard to write?