### PR TITLE
MNT: Use `importlib` instead of `pkg_resources` to retrieve files

### DIFF
--- a/src/nifreeze/registration/ants.py
+++ b/src/nifreeze/registration/ants.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from importlib.resources import files
 from json import loads
 from pathlib import Path
 from warnings import warn
@@ -34,7 +35,6 @@ import nitransforms as nt
 import numpy as np
 from nipype.interfaces.ants.registration import Registration
 from nitransforms.linear import Affine
-from pkg_resources import resource_filename as pkg_fn
 
 PARAMETERS_SINGLE_VALUE = {
     "collapse_output_transforms",
@@ -180,12 +180,7 @@ def _get_ants_settings(settings: str = "b0-to-b0_level0") -> Path:
     PosixPath('.../config/b0-to-b0_level1.json')
 
     """
-    return Path(
-        pkg_fn(
-            "nifreeze.registration",
-            f"config/{settings}.json",
-        )
-    )
+    return Path(str(files("nifreeze.registration").joinpath(f"config/{settings}.json")))
 
 
 def _massage_mask_path(mask_path: str | Path | list[str], nlevels: int) -> list[str]:

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -22,6 +22,7 @@
 #
 """Unit tests exercising the estimator."""
 
+from importlib.resources import files
 from os import cpu_count
 
 import nibabel as nb
@@ -31,7 +32,6 @@ import pytest
 from nibabel.affines import from_matvec
 from nibabel.eulerangles import euler2mat
 from nipype.interfaces.ants.registration import Registration
-from pkg_resources import resource_filename as pkg_fn
 
 from nifreeze.registration.ants import _massage_mask_path
 from nifreeze.registration.utils import displacements_within_mask
@@ -61,10 +61,7 @@ def test_ANTs_config_b0(datadir, tmp_path, dataset, r_x, r_y, r_z, t_x, t_y, t_z
 
     registration = Registration(
         terminal_output="file",
-        from_file=pkg_fn(
-            "nifreeze.registration",
-            "config/b0-to-b0_level0.json",
-        ),
+        from_file=files("nifreeze.registration").joinpath("config/b0-to-b0_level0.json"),
         fixed_image=str(fixed.absolute()),
         moving_image=str(moving.absolute()),
         fixed_image_masks=[str(fixed_mask)],


### PR DESCRIPTION
Use `importlib` instead of `pkg_resources` to retrieve package resource files.

```
src/nifreeze/registration/ants.py:37
src/nifreeze/registration/ants.py:37
   /home/runner/work/nifreeze/nifreeze/src/nifreeze/registration/ants.py:37:
 UserWarning: pkg_resources is deprecated as an API.
 See https://setuptools.pypa.io/en/latest/pkg_resources.html.
 The pkg_resources package is slated for removal as early as 2025-11-30.
 Refrain from using this package or pin to Setuptools<81.
       from pkg_resources import resource_filename as pkg_fn
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/15301631097/job/43043463683#step:11:266