### PR TITLE
STY: Ignore `Hyperparameter` class instantiation type check.

### DIFF
--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -288,11 +288,11 @@ class ExponentialKriging(Kernel):
 
     @property
     def hyperparameter_a(self) -> Hyperparameter:
-        return Hyperparameter("beta_a", "numeric", self.a_bounds)
+        return Hyperparameter("beta_a", "numeric", self.a_bounds)  # type: ignore
 
     @property
     def hyperparameter_l(self) -> Hyperparameter:
-        return Hyperparameter("beta_l", "numeric", self.l_bounds)
+        return Hyperparameter("beta_l", "numeric", self.l_bounds)  # type: ignore
 
     def __call__(
         self, X: np.ndarray, Y: np.ndarray | None = None, eval_gradient: bool = False
@@ -393,11 +393,11 @@ class SphericalKriging(Kernel):
 
     @property
     def hyperparameter_a(self) -> Hyperparameter:
-        return Hyperparameter("beta_a", "numeric", self.a_bounds)
+        return Hyperparameter("beta_a", "numeric", self.a_bounds)  # type: ignore
 
     @property
     def hyperparameter_l(self) -> Hyperparameter:
-        return Hyperparameter("beta_l", "numeric", self.l_bounds)
+        return Hyperparameter("beta_l", "numeric", self.l_bounds)  # type: ignore
 
     def __call__(
         self, X: np.ndarray, Y: np.ndarray | None = None, eval_gradient: bool = False


### PR DESCRIPTION
Ignore `scikit-learn` `Hyperparameter` class instantiation type check.

According to the version documentation, `name`, `value_type` and `bounds` are positional arguments, and are provided as such. Additionally, `name` and `value_type` are expected to have `str` types, which they do:
https://scikit-learn.org/1.6/modules/generated/sklearn.gaussian_process.kernels.Hyperparameter.html

So consider the warning as a false positive and ignore it.

Fixes:
```
src/nifreeze/model/gpr.py:291: error: Missing positional arguments "value_type", "name" in call to "Hyperparameter"  [call-arg]
src/nifreeze/model/gpr.py:291: error: Argument 1 to "Hyperparameter" has incompatible type "str"; expected "bool"  [arg-type]
src/nifreeze/model/gpr.py:291: error: Argument 2 to "Hyperparameter" has incompatible type "str"; expected "int"  [arg-type]
src/nifreeze/model/gpr.py:295: error: Missing positional arguments "value_type", "name" in call to "Hyperparameter"  [call-arg]
src/nifreeze/model/gpr.py:295: error: Argument 1 to "Hyperparameter" has incompatible type "str"; expected "bool"  [arg-type]
src/nifreeze/model/gpr.py:295: error: Argument 2 to "Hyperparameter" has incompatible type "str"; expected "int"  [arg-type]
src/nifreeze/model/gpr.py:396: error: Missing positional arguments "value_type", "name" in call to "Hyperparameter"  [call-arg]
src/nifreeze/model/gpr.py:396: error: Argument 1 to "Hyperparameter" has incompatible type "str"; expected "bool"  [arg-type]
src/nifreeze/model/gpr.py:396: error: Argument 2 to "Hyperparameter" has incompatible type "str"; expected "int"  [arg-type]
src/nifreeze/model/gpr.py:400: error: Missing positional arguments "value_type", "name" in call to "Hyperparameter"  [call-arg]
src/nifreeze/model/gpr.py:400: error: Argument 1 to "Hyperparameter" has incompatible type "str"; expected "bool"  [arg-type]
src/nifreeze/model/gpr.py:400: error: Argument 2 to "Hyperparameter" has incompatible type "str"; expected "int"  [arg-type]
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/15337284082/job/43185631165#step:8:33