### PR TITLE
TST: Add Python 3.13 to the testing suite

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
     needs: ['cache-test-data']
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add Python 3.13 to the testing suite and the versions for which the packaging is tested.

Python 3.13 was released in October 2024, and Python 3.14 will be released in October 2025, so it seems reasonable to start testing on Python 3.13.

Release notes:
https://www.python.org/downloads/release/python-3130/