### PR TITLE
MNT: Adopt reduced and regular schemes for CI Python build matrix

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.12' ]
 
     steps:
     - name: Set up system

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,6 +9,8 @@ on:
     tags: [ '*' ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '0 22 * * 0' # At 22:00 UTC every Sunday
 
 jobs:
   build:
@@ -16,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ${{ github.event_name == 'schedule' && fromJson('["3.10", "3.11", "3.12", "3.13"]') || fromJson('["3.12"]') }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
       - maint/*
   # Allow job to be triggered manually from GitHub interface
   workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * 0' # At 22:00 UTC every Sunday
 
 defaults:
   run:
@@ -96,7 +98,7 @@ jobs:
     needs: ['cache-test-data']
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ${{ github.event_name == 'schedule' && fromJson('["3.10", "3.11", "3.12", "3.13"]') || fromJson('["3.12"]') }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adopt reduced and regular schemes for CI Python build matrix:
- Use Python 3.12 for CI testing and packaging.
- Add a weekly job that uses an extended set of Python versions for testing and packaging.

Change the Python version in the benchmark GHA workflow file to use Python 3.12.