### PR TITLE
ENH: Implement ``MultiShellKernel``

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,11 @@ module = [
   "joblib",
   "h5py",
   "ConfigSpace",
+  "scipy.*",
+  "sklearn.*",
+  "skimage.*",
+  "pandas",
+  "attrs",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,9 @@ module = [
   "ConfigSpace",
   "scipy.*",
   "sklearn.*",
+  "skimage.*",
+  "pandas",
+  "attrs",
 ]
 ignore_missing_imports = true
 

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -43,15 +43,8 @@ GP_JITTER = 1e-10
 """Small nugget kept on ``alpha`` for numerical stability."""
 
 
-def _cartesian_components(gtab: GradientTable | np.ndarray) -> np.ndarray:
-    """Return the design matrix ``[gx, gy, gz, bval]``.
-
-    The b-value is always appended as a trailing column (layout
-    ``[gx, gy, gz, bval]``) so multi-shell kernels can access it. Single-shell
-    kernels operate on orientations only and drop the b-value column downstream
-    (see :func:`_design_matrix`).
-    """
-
+def _btable_asarray(gtab: GradientTable | np.ndarray) -> np.ndarray:
+    """Return the design matrix ``[gx, gy, gz, bval]``."""
     if hasattr(gtab, "bvecs"):
         gtab = cast(GradientTable, gtab)
         return np.column_stack([gtab.bvecs, np.asarray(gtab.bvals)])
@@ -60,19 +53,6 @@ def _cartesian_components(gtab: GradientTable | np.ndarray) -> np.ndarray:
     if components.ndim == 1:
         components = components[np.newaxis, :]
     return components
-
-
-def _design_matrix(gtab: GradientTable | np.ndarray, kernel: Kernel | None) -> np.ndarray:
-    """Build the GP design matrix appropriate for ``kernel``.
-
-    The b-value is always available in the Cartesian components; a single-shell
-    kernel only consumes orientations, so its trailing b-value column is dropped
-    here (multi-shell kernels keep it, selecting columns via ``bval_index``).
-    """
-    X = _cartesian_components(gtab)
-    if not isinstance(kernel, MultiShellKernel) and X.shape[-1] > 3:
-        X = X[:, :3]
-    return X
 
 
 def gp_prediction(
@@ -106,7 +86,10 @@ def gp_prediction(
 
     """
 
-    X = _design_matrix(gtab, getattr(model, "kernel", None))
+    X = _btable_asarray(gtab)
+    # Single-shell kernels consume orientations only; drop the b-value column.
+    if not isinstance(getattr(model, "kernel", None), MultiShellKernel):
+        X = X[:, :3]
 
     # Check it's fitted as they do in sklearn internally
     # https://github.com/scikit-learn/scikit-learn/blob/972e17fe1aa12d481b120ad4a3dc076bae736931/\
@@ -225,11 +208,13 @@ class GaussianProcessModel(ReconstModel):
 
         """
 
-        # Extract b-vecs: scikit-learn wants (n_samples, n_features) where
-        # n_samples is the different diffusion-encoding gradient orientations.
-        # n_features is 3 (orientation only), or 4 ([gx, gy, gz, bval]) when a
-        # multi-shell kernel needs the b-value.
-        X = _design_matrix(gtab, self.kernel)
+        # scikit-learn wants (n_samples, n_features), where n_samples is the
+        # number of diffusion-encoding gradient orientations. n_features is 4
+        # ([gx, gy, gz, bval]) for the multi-shell kernel; single-shell kernels
+        # consume orientations only, so the b-value column is dropped.
+        X = _btable_asarray(gtab)
+        if not isinstance(self.kernel, MultiShellKernel):
+            X = X[:, :3]
 
         # Data must have shape (n_samples, n_targets) where n_samples is
         # the number of diffusion-encoding gradient orientations, and n_targets

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -24,15 +24,18 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 from dipy.core.gradients import GradientTable
 from dipy.reconst.base import ReconstModel
 from sklearn.gaussian_process import GaussianProcessRegressor
-from sklearn.gaussian_process.kernels import WhiteKernel
+from sklearn.gaussian_process.kernels import RBF, Kernel, KernelOperator, WhiteKernel
 
 from nifreeze.model.gpr import (
     DiffusionGPR,
     ExponentialKriging,
+    MultiShellKernel,
     SphericalKriging,
 )
 
@@ -40,18 +43,42 @@ GP_JITTER = 1e-10
 """Small nugget kept on ``alpha`` for numerical stability."""
 
 
-def _cartesian_components(gtab: GradientTable | np.ndarray) -> np.ndarray:
-    """Return the gradient directions as Cartesian components."""
+def _cartesian_components(gtab: GradientTable | np.ndarray, keep_bval: bool = False) -> np.ndarray:
+    """Return the gradient directions as Cartesian components.
+
+    When ``keep_bval`` is :obj:`True`, the b-value is appended as a trailing
+    column (layout ``[gx, gy, gz, bval]``) so multi-shell kernels can access it;
+    otherwise only the 3 orientation components are returned.
+    """
 
     if hasattr(gtab, "bvecs"):
+        gtab = cast(GradientTable, gtab)
         components = gtab.bvecs
+        if keep_bval:
+            components = np.column_stack([components, np.asarray(gtab.bvals)])
     else:
         components = np.asarray(gtab)
         if components.ndim == 1:
             components = components[np.newaxis, :]
-        if components.shape[-1] > 3:
+        if not keep_bval and components.shape[-1] > 3:
             components = components[:, :-1]
     return components
+
+
+def _kernel_uses_bval(kernel: Kernel | None) -> bool:
+    """Return whether ``kernel`` (possibly compound) contains a multi-shell kernel.
+
+    The b-value column is only needed in the design matrix when a
+    :obj:`~nifreeze.model.gpr.MultiShellKernel` is somewhere in the kernel. Because
+    the measurement-noise :obj:`~sklearn.gaussian_process.kernels.WhiteKernel` is
+    added as a :obj:`~sklearn.gaussian_process.kernels.KernelOperator`, the check
+    must recurse into the operands.
+    """
+    if isinstance(kernel, MultiShellKernel):
+        return True
+    if isinstance(kernel, KernelOperator):
+        return _kernel_uses_bval(kernel.k1) or _kernel_uses_bval(kernel.k2)
+    return False
 
 
 def gp_prediction(
@@ -85,7 +112,8 @@ def gp_prediction(
 
     """
 
-    X = _cartesian_components(gtab)
+    keep_bval = _kernel_uses_bval(getattr(model, "kernel", None))
+    X = _cartesian_components(gtab, keep_bval=keep_bval)
 
     # Check it's fitted as they do in sklearn internally
     # https://github.com/scikit-learn/scikit-learn/blob/972e17fe1aa12d481b120ad4a3dc076bae736931/\
@@ -93,7 +121,7 @@ def gp_prediction(
     if not hasattr(model, "X_train_"):
         raise RuntimeError("Model is not yet fitted.")
 
-    # Extract orientations from bvecs, and highly likely, the b-value too.
+    # X holds the gradient orientations (and the b-value too, for multi-shell).
     orientations = model.predict(X, return_std=return_std)
     assert isinstance(orientations, np.ndarray)
     return orientations
@@ -114,6 +142,7 @@ class GaussianProcessModel(ReconstModel):
         beta_l: float = 2.0,
         beta_a: float = 0.1,
         sigma_sq: float = 1.0,
+        ell: float = 1.0,
         *args,
         **kwargs,
     ) -> None:
@@ -125,8 +154,11 @@ class GaussianProcessModel(ReconstModel):
         Parameters
         ----------
         kernel_model : :obj:`str`, optional
-            Angular covariance model, ``"spherical"`` (default) or
-            ``"exponential"``.
+            Angular covariance model. One of ``"spherical"`` (default),
+            ``"exponential"``, or ``"multishell"``. ``"multishell"`` builds a
+            :obj:`~nifreeze.model.gpr.MultiShellKernel` (angular × radial product,
+            Eqs. 14–15) and expects the b-value to be preserved in the design
+            matrix.
         beta_l : :obj:`float`, optional
             Signal scale parameter determining the variability of the signal.
         beta_a : :obj:`float`, optional
@@ -139,6 +171,9 @@ class GaussianProcessModel(ReconstModel):
             :obj:`~sklearn.gaussian_process.kernels.WhiteKernel` added to the
             covariance kernel, and is *optimized* along with the other
             hyperparameters (rather than held fixed as in a plain ``alpha``).
+        ell : :obj:`float`, optional
+            Radial (log-b) length scale for the multi-shell kernel (:math:`\\ell`
+            in Eq. 15). Only used when ``kernel_model == "multishell"``.
 
         References
         ----------
@@ -150,12 +185,18 @@ class GaussianProcessModel(ReconstModel):
 
         self.sigma_sq = sigma_sq
 
-        KernelType = SphericalKriging if kernel_model == "spherical" else ExponentialKriging
-        # Add the :math:`\sigma^2` term of Andersson et al. (2015) as a WhiteKernel
-        self.kernel = KernelType(
-            beta_a=beta_a,
-            beta_l=beta_l,
-        ) + WhiteKernel(noise_level=sigma_sq)
+        if kernel_model == "multishell":
+            self.kernel = MultiShellKernel(
+                orientation_kernel=SphericalKriging(beta_a=beta_a, beta_l=beta_l),
+                radial_kernel=RBF(length_scale=ell),
+            )
+        else:
+            KernelType = SphericalKriging if kernel_model == "spherical" else ExponentialKriging
+            # Add the :math:`\sigma^2` term of Andersson et al. (2015) as a WhiteKernel
+            self.kernel = KernelType(
+                beta_a=beta_a,
+                beta_l=beta_l,
+            ) + WhiteKernel(noise_level=sigma_sq)
 
     def fit(
         self,
@@ -186,10 +227,12 @@ class GaussianProcessModel(ReconstModel):
 
         """
 
-        # Extract b-vecs: scikit-learn wants (n_samples, n_features)
-        # where n_features is 3, and n_samples the different diffusion-encoding
-        # gradient orientations.
-        X = _cartesian_components(gtab)
+        # Extract b-vecs: scikit-learn wants (n_samples, n_features) where
+        # n_samples is the different diffusion-encoding gradient orientations.
+        # n_features is 3 (orientation only), or 4 ([gx, gy, gz, bval]) when a
+        # multi-shell kernel needs the b-value.
+        keep_bval = _kernel_uses_bval(self.kernel)
+        X = _cartesian_components(gtab, keep_bval=keep_bval)
 
         # Data must have shape (n_samples, n_targets) where n_samples is
         # the number of diffusion-encoding gradient orientations, and n_targets

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -30,7 +30,7 @@ import numpy as np
 from dipy.core.gradients import GradientTable
 from dipy.reconst.base import ReconstModel
 from sklearn.gaussian_process import GaussianProcessRegressor
-from sklearn.gaussian_process.kernels import RBF, Kernel, KernelOperator, WhiteKernel
+from sklearn.gaussian_process.kernels import RBF, Kernel, WhiteKernel
 
 from nifreeze.model.gpr import (
     DiffusionGPR,
@@ -43,42 +43,36 @@ GP_JITTER = 1e-10
 """Small nugget kept on ``alpha`` for numerical stability."""
 
 
-def _cartesian_components(gtab: GradientTable | np.ndarray, keep_bval: bool = False) -> np.ndarray:
-    """Return the gradient directions as Cartesian components.
+def _cartesian_components(gtab: GradientTable | np.ndarray) -> np.ndarray:
+    """Return the design matrix ``[gx, gy, gz, bval]``.
 
-    When ``keep_bval`` is :obj:`True`, the b-value is appended as a trailing
-    column (layout ``[gx, gy, gz, bval]``) so multi-shell kernels can access it;
-    otherwise only the 3 orientation components are returned.
+    The b-value is always appended as a trailing column (layout
+    ``[gx, gy, gz, bval]``) so multi-shell kernels can access it. Single-shell
+    kernels operate on orientations only and drop the b-value column downstream
+    (see :func:`_design_matrix`).
     """
 
     if hasattr(gtab, "bvecs"):
         gtab = cast(GradientTable, gtab)
-        components = gtab.bvecs
-        if keep_bval:
-            components = np.column_stack([components, np.asarray(gtab.bvals)])
-    else:
-        components = np.asarray(gtab)
-        if components.ndim == 1:
-            components = components[np.newaxis, :]
-        if not keep_bval and components.shape[-1] > 3:
-            components = components[:, :-1]
+        return np.column_stack([gtab.bvecs, np.asarray(gtab.bvals)])
+
+    components = np.asarray(gtab)
+    if components.ndim == 1:
+        components = components[np.newaxis, :]
     return components
 
 
-def _kernel_uses_bval(kernel: Kernel | None) -> bool:
-    """Return whether ``kernel`` (possibly compound) contains a multi-shell kernel.
+def _design_matrix(gtab: GradientTable | np.ndarray, kernel: Kernel | None) -> np.ndarray:
+    """Build the GP design matrix appropriate for ``kernel``.
 
-    The b-value column is only needed in the design matrix when a
-    :obj:`~nifreeze.model.gpr.MultiShellKernel` is somewhere in the kernel. Because
-    the measurement-noise :obj:`~sklearn.gaussian_process.kernels.WhiteKernel` is
-    added as a :obj:`~sklearn.gaussian_process.kernels.KernelOperator`, the check
-    must recurse into the operands.
+    The b-value is always available in the Cartesian components; a single-shell
+    kernel only consumes orientations, so its trailing b-value column is dropped
+    here (multi-shell kernels keep it, selecting columns via ``bval_index``).
     """
-    if isinstance(kernel, MultiShellKernel):
-        return True
-    if isinstance(kernel, KernelOperator):
-        return _kernel_uses_bval(kernel.k1) or _kernel_uses_bval(kernel.k2)
-    return False
+    X = _cartesian_components(gtab)
+    if not isinstance(kernel, MultiShellKernel) and X.shape[-1] > 3:
+        X = X[:, :3]
+    return X
 
 
 def gp_prediction(
@@ -112,8 +106,7 @@ def gp_prediction(
 
     """
 
-    keep_bval = _kernel_uses_bval(getattr(model, "kernel", None))
-    X = _cartesian_components(gtab, keep_bval=keep_bval)
+    X = _design_matrix(gtab, getattr(model, "kernel", None))
 
     # Check it's fitted as they do in sklearn internally
     # https://github.com/scikit-learn/scikit-learn/blob/972e17fe1aa12d481b120ad4a3dc076bae736931/\
@@ -156,9 +149,13 @@ class GaussianProcessModel(ReconstModel):
         kernel_model : :obj:`str`, optional
             Angular covariance model. One of ``"spherical"`` (default),
             ``"exponential"``, or ``"multishell"``. ``"multishell"`` builds a
-            :obj:`~nifreeze.model.gpr.MultiShellKernel` (angular × radial product,
-            Eqs. 14–15) and expects the b-value to be preserved in the design
-            matrix.
+            :obj:`~nifreeze.model.gpr.MultiShellKernel` as the product of a
+            **spherical** angular covariance and a radial (log-b) kernel
+            (Eqs. 14–15), and expects the b-value to be preserved in the design
+            matrix. :footcite:t:`andersson_non-parametric_2015` only investigated
+            the multi-shell model with the spherical covariance; the exponential
+            covariance was characterized for the single-shell case, so it is not
+            wired into the multi-shell kernel here.
         beta_l : :obj:`float`, optional
             Signal scale parameter determining the variability of the signal.
         beta_a : :obj:`float`, optional
@@ -185,6 +182,7 @@ class GaussianProcessModel(ReconstModel):
 
         self.sigma_sq = sigma_sq
 
+        self.kernel: Kernel
         if kernel_model == "multishell":
             self.kernel = MultiShellKernel(
                 orientation_kernel=SphericalKriging(beta_a=beta_a, beta_l=beta_l),
@@ -231,8 +229,7 @@ class GaussianProcessModel(ReconstModel):
         # n_samples is the different diffusion-encoding gradient orientations.
         # n_features is 3 (orientation only), or 4 ([gx, gy, gz, bval]) when a
         # multi-shell kernel needs the b-value.
-        keep_bval = _kernel_uses_bval(self.kernel)
-        X = _cartesian_components(gtab, keep_bval=keep_bval)
+        X = _design_matrix(gtab, self.kernel)
 
         # Data must have shape (n_samples, n_targets) where n_samples is
         # the number of diffusion-encoding gradient orientations, and n_targets

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -501,5 +501,5 @@ class GQIModel(BaseDWIModel):
 class GPModel(BaseDWIModel):
     """A wrapper of :obj:`~nifreeze.model.dipy.GaussianProcessModel`."""
 
-    _modelargs = ("kernel_model",)
+    _modelargs = ("kernel_model", "beta_l", "beta_a", "sigma_sq", "ell")
     _model_class = "nifreeze.model._dipy.GaussianProcessModel"

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -252,7 +252,7 @@ class DiffusionGPR(GaussianProcessRegressor):
                 options=options,
                 args=(self.eval_gradient,),
                 tol=self.tol,
-            )
+            )  # type: ignore[call-overload]
             return opt_res.x, opt_res.fun
 
         if callable(self.optimizer):
@@ -479,6 +479,9 @@ class SphericalKriging(Kernel):
 class MultiShellKernel(KernelOperator):
     """Composite kernel for multi-shell diffusion data."""
 
+    k1: Kernel
+    k2: Kernel
+
     def __init__(
         self,
         orientation_kernel: Kernel | None = None,
@@ -511,10 +514,13 @@ class MultiShellKernel(KernelOperator):
         eval_gradient: bool = False,
     ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         X_o, X_b = self._split(X)
+        Y_o: np.ndarray | None
+        Y_b: np.ndarray | None
         if Y is not None:
             Y_o, Y_b = self._split(Y)
         else:
-            Y_o = Y_b = None
+            Y_o = None
+            Y_b = None
 
         if eval_gradient:
             K1, g1 = self.k1(X_o, Y_o, eval_gradient=True)

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -489,17 +489,22 @@ class MultiShellKernel(KernelOperator):
         orientation_dims: Sequence[int] = (0, 1, 2),
         bval_index: int = 3,
     ) -> None:
-        super().__init__(
-            orientation_kernel if orientation_kernel is not None else SphericalKriging(),
-            radial_kernel if radial_kernel is not None else RBF(length_scale=1.0),
-        )
+        # Store init params for sklearn cloning
+        self.orientation_kernel = orientation_kernel if orientation_kernel is not None else SphericalKriging()
+        self.radial_kernel = radial_kernel if radial_kernel is not None else RBF(length_scale=1.0)
         self.orientation_dims = tuple(orientation_dims)
         self.bval_index = bval_index
 
+        super().__init__(self.orientation_kernel, self.radial_kernel,)
+
     def get_params(self, deep: bool = True):  # noqa: D401
-        params = super().get_params(deep=deep)
-        params.update({"orientation_dims": self.orientation_dims, "bval_index": self.bval_index})
-        return params
+        # Return only __init__ parameters (sklearn clone() relies on this)
+        return {
+            "orientation_kernel": self.orientation_kernel,
+            "radial_kernel": self.radial_kernel,
+            "orientation_dims": self.orientation_dims,
+            "bval_index": self.bval_index,
+        }
 
     def _split(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         X = np.asarray(X)

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -33,8 +33,10 @@ from scipy import optimize
 from scipy.optimize import Bounds
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import (
+    RBF,
     Hyperparameter,
     Kernel,
+    KernelOperator,
 )
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.utils._param_validation import Interval, StrOptions
@@ -97,8 +99,9 @@ class DiffusionGPR(GaussianProcessRegressor):
     selection through gradient-descent with analytical gradient calculations
     would not work (the derivative of the kernel w.r.t. ``alpha`` is zero).
 
-    This might have been overlooked in :footcite:p:`andersson_non-parametric_2015` or else they actually did
-    not use analytical gradient-descent:
+    This might have been overlooked in
+    :footcite:p:`andersson_non-parametric_2015` or else they actually did not
+    use analytical gradient-descent:
 
         *A note on optimisation*
 
@@ -473,11 +476,67 @@ class SphericalKriging(Kernel):
         return f"SphericalKriging (a={self.beta_a}, λ={self.beta_l})"
 
 
+class MultiShellKernel(KernelOperator):
+    """Composite kernel for multi-shell diffusion data."""
+
+    def __init__(
+        self,
+        orientation_kernel: Kernel | None = None,
+        radial_kernel: Kernel | None = None,
+        orientation_dims: Sequence[int] = (0, 1, 2),
+        bval_index: int = 3,
+    ) -> None:
+        super().__init__(
+            orientation_kernel if orientation_kernel is not None else SphericalKriging(),
+            radial_kernel if radial_kernel is not None else RBF(length_scale=1.0),
+        )
+        self.orientation_dims = tuple(orientation_dims)
+        self.bval_index = bval_index
+
+    def get_params(self, deep: bool = True):  # noqa: D401
+        params = super().get_params(deep=deep)
+        params.update({"orientation_dims": self.orientation_dims, "bval_index": self.bval_index})
+        return params
+
+    def _split(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        X = np.asarray(X)
+        orient = X[:, self.orientation_dims]
+        bvals = np.log(X[:, self.bval_index]).reshape(-1, 1)
+        return orient, bvals
+
+    def __call__(
+        self,
+        X: np.ndarray,
+        Y: np.ndarray | None = None,
+        eval_gradient: bool = False,
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        X_o, X_b = self._split(X)
+        if Y is not None:
+            Y_o, Y_b = self._split(Y)
+        else:
+            Y_o = Y_b = None
+
+        if eval_gradient:
+            K1, g1 = self.k1(X_o, Y_o, eval_gradient=True)
+            K2, g2 = self.k2(X_b, Y_b, eval_gradient=True)
+            return K1 * K2, np.dstack((g1 * K2[:, :, np.newaxis], g2 * K1[:, :, np.newaxis]))
+
+        return self.k1(X_o, Y_o) * self.k2(X_b, Y_b)
+
+    def diag(self, X: npt.ArrayLike) -> np.ndarray:
+        X_o, X_b = self._split(np.asarray(X))
+        return self.k1.diag(X_o) * self.k2.diag(X_b)
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"MultiShellKernel({self.k1} * {self.k2})"
+
+
 def exponential_covariance(theta: np.ndarray, a: float) -> np.ndarray:
     r"""
     Compute the exponential covariance for given distances and scale parameter.
 
-    Implements :math:`C_{\theta}`, following Eq. (9) in :footcite:p:`andersson_non-parametric_2015`:
+    Implements :math:`C_{\theta}`, following Eq. (9) in
+    :footcite:p:`andersson_non-parametric_2015`:
 
     .. math::
         \begin{equation}
@@ -513,7 +572,8 @@ def spherical_covariance(theta: np.ndarray, a: float) -> np.ndarray:
     r"""
     Compute the spherical covariance for given distances and scale parameter.
 
-    Implements :math:`C_{\theta}`, following Eq. (10) in :footcite:p:`andersson_non-parametric_2015`:
+    Implements :math:`C_{\theta}`, following Eq. (10) in
+    :footcite:p:`andersson_non-parametric_2015`:
 
     .. math::
         \begin{equation}
@@ -557,8 +617,9 @@ def compute_pairwise_angles(
 ) -> np.ndarray:
     r"""Compute pairwise angles across diffusion gradient encoding directions.
 
-    Following :footcite:p:`andersson_non-parametric_2015`:, it computes the smallest of the angles between
-    each pair if ``closest_polarity`` is :obj:`True`, i.e.,
+    Following :footcite:p:`andersson_non-parametric_2015`, it computes the
+    smallest of the angles between each pair if ``closest_polarity`` is ``True``,
+    i.e.,
 
     .. math::
 

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -490,12 +490,14 @@ class MultiShellKernel(KernelOperator):
         bval_index: int = 3,
     ) -> None:
         # Store init params for sklearn cloning
-        self.orientation_kernel = orientation_kernel if orientation_kernel is not None else SphericalKriging()
+        self.orientation_kernel = (
+            orientation_kernel if orientation_kernel is not None else SphericalKriging()
+        )
         self.radial_kernel = radial_kernel if radial_kernel is not None else RBF(length_scale=1.0)
         self.orientation_dims = tuple(orientation_dims)
         self.bval_index = bval_index
 
-        super().__init__(self.orientation_kernel, self.radial_kernel,)
+        super().__init__(self.orientation_kernel, self.radial_kernel)
 
     def get_params(self, deep: bool = True):  # noqa: D401
         # Return only __init__ parameters (sklearn clone() relies on this)

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -347,7 +347,7 @@ class ExponentialKriging(Kernel):
         if not eval_gradient:
             return self.beta_l * C_theta
 
-        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
+        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter.
         K_gradient = np.zeros((*thetas.shape, 2))
         K_gradient[..., 0] = self.beta_l * C_theta * thetas / self.beta_a  # d/d(log a)
         K_gradient[..., 1] = self.beta_l * C_theta  # d/d(log lambda)
@@ -453,7 +453,7 @@ class SphericalKriging(Kernel):
         if not eval_gradient:
             return self.beta_l * C_theta
 
-        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
+        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter.
         deriv_a = np.zeros_like(thetas)
         nonzero = thetas <= self.beta_a
         deriv_a[nonzero] = (
@@ -572,11 +572,9 @@ class MultiShellKernel(KernelOperator):
             ("radial_kernel", self.radial_kernel),
         ):
             for hp in kernel.hyperparameters:  # type: ignore[attr-defined]
-                r.append(
-                    Hyperparameter(  # type: ignore[call-arg,arg-type]
-                        f"{prefix}__{hp.name}", hp.value_type, hp.bounds, hp.n_elements
-                    )
-                )
+                # ``Hyperparameter`` is a namedtuple; ``_replace`` re-prefixes the
+                # name while preserving value_type/bounds/n_elements/fixed.
+                r.append(hp._replace(name=f"{prefix}__{hp.name}"))
         return r
 
     def _split(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -612,7 +612,7 @@ class MultiShellKernel(KernelOperator):
         X_o, X_b = self._split(np.asarray(X))
         return self.k1.diag(X_o) * self.k2.diag(X_b)
 
-    def __repr__(self) -> str:  # pragma: no cover - simple representation
+    def __repr__(self) -> str:
         return f"MultiShellKernel({self.k1} * {self.k2})"
 
 

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -248,7 +248,7 @@ class DiffusionGPR(GaussianProcessRegressor):
                 options=options,
                 args=(self.eval_gradient,),
                 tol=self.tol,
-            )
+            )  # type: ignore[call-overload]
             return opt_res.x, opt_res.fun
 
         if callable(self.optimizer):
@@ -479,6 +479,9 @@ class SphericalKriging(Kernel):
 class MultiShellKernel(KernelOperator):
     """Composite kernel for multi-shell diffusion data."""
 
+    k1: Kernel
+    k2: Kernel
+
     def __init__(
         self,
         orientation_kernel: Kernel | None = None,
@@ -511,10 +514,13 @@ class MultiShellKernel(KernelOperator):
         eval_gradient: bool = False,
     ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         X_o, X_b = self._split(X)
+        Y_o: np.ndarray | None
+        Y_b: np.ndarray | None
         if Y is not None:
             Y_o, Y_b = self._split(Y)
         else:
-            Y_o = Y_b = None
+            Y_o = None
+            Y_b = None
 
         if eval_gradient:
             K1, g1 = self.k1(X_o, Y_o, eval_gradient=True)

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -348,8 +348,6 @@ class ExponentialKriging(Kernel):
             return self.beta_l * C_theta
 
         # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
-        # (``Kernel.theta`` is log-transformed), hence the chain-rule factors of
-        # ``beta_a`` and ``beta_l``.
         K_gradient = np.zeros((*thetas.shape, 2))
         K_gradient[..., 0] = self.beta_l * C_theta * thetas / self.beta_a  # d/d(log a)
         K_gradient[..., 1] = self.beta_l * C_theta  # d/d(log lambda)
@@ -456,8 +454,6 @@ class SphericalKriging(Kernel):
             return self.beta_l * C_theta
 
         # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
-        # (``Kernel.theta`` is log-transformed), hence the chain-rule factors of
-        # ``beta_a`` and ``beta_l``.
         deriv_a = np.zeros_like(thetas)
         nonzero = thetas <= self.beta_a
         deriv_a[nonzero] = (
@@ -568,16 +564,18 @@ class MultiShellKernel(KernelOperator):
         return params
 
     @property
-    def hyperparameters(self) -> list[Hyperparameter]:
+    def hyperparameters(self) -> list[Hyperparameter]:  # type: ignore[override]
         """Expose sub-kernel hyperparameters under the constructor's names."""
         r = []
         for prefix, kernel in (
             ("orientation_kernel", self.orientation_kernel),
             ("radial_kernel", self.radial_kernel),
         ):
-            for hp in kernel.hyperparameters:
+            for hp in kernel.hyperparameters:  # type: ignore[attr-defined]
                 r.append(
-                    Hyperparameter(f"{prefix}__{hp.name}", hp.value_type, hp.bounds, hp.n_elements)
+                    Hyperparameter(  # type: ignore[call-arg,arg-type]
+                        f"{prefix}__{hp.name}", hp.value_type, hp.bounds, hp.n_elements
+                    )
                 )
         return r
 

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -33,8 +33,10 @@ from scipy import optimize
 from scipy.optimize import Bounds
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import (
+    RBF,
     Hyperparameter,
     Kernel,
+    KernelOperator,
 )
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.utils._param_validation import Interval, StrOptions
@@ -474,11 +476,67 @@ class SphericalKriging(Kernel):
         return f"SphericalKriging (a={self.beta_a}, λ={self.beta_l})"
 
 
+class MultiShellKernel(KernelOperator):
+    """Composite kernel for multi-shell diffusion data."""
+
+    def __init__(
+        self,
+        orientation_kernel: Kernel | None = None,
+        radial_kernel: Kernel | None = None,
+        orientation_dims: Sequence[int] = (0, 1, 2),
+        bval_index: int = 3,
+    ) -> None:
+        super().__init__(
+            orientation_kernel if orientation_kernel is not None else SphericalKriging(),
+            radial_kernel if radial_kernel is not None else RBF(length_scale=1.0),
+        )
+        self.orientation_dims = tuple(orientation_dims)
+        self.bval_index = bval_index
+
+    def get_params(self, deep: bool = True):  # noqa: D401
+        params = super().get_params(deep=deep)
+        params.update({"orientation_dims": self.orientation_dims, "bval_index": self.bval_index})
+        return params
+
+    def _split(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        X = np.asarray(X)
+        orient = X[:, self.orientation_dims]
+        bvals = np.log(X[:, self.bval_index]).reshape(-1, 1)
+        return orient, bvals
+
+    def __call__(
+        self,
+        X: np.ndarray,
+        Y: np.ndarray | None = None,
+        eval_gradient: bool = False,
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        X_o, X_b = self._split(X)
+        if Y is not None:
+            Y_o, Y_b = self._split(Y)
+        else:
+            Y_o = Y_b = None
+
+        if eval_gradient:
+            K1, g1 = self.k1(X_o, Y_o, eval_gradient=True)
+            K2, g2 = self.k2(X_b, Y_b, eval_gradient=True)
+            return K1 * K2, np.dstack((g1 * K2[:, :, np.newaxis], g2 * K1[:, :, np.newaxis]))
+
+        return self.k1(X_o, Y_o) * self.k2(X_b, Y_b)
+
+    def diag(self, X: npt.ArrayLike) -> np.ndarray:
+        X_o, X_b = self._split(np.asarray(X))
+        return self.k1.diag(X_o) * self.k2.diag(X_b)
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"MultiShellKernel({self.k1} * {self.k2})"
+
+
 def exponential_covariance(theta: np.ndarray, a: float) -> np.ndarray:
     r"""
     Compute the exponential covariance for given distances and scale parameter.
 
-    Implements :math:`C_{\theta}`, following Eq. (9) in :footcite:p:`andersson_non-parametric_2015`:
+    Implements :math:`C_{\theta}`, following Eq. (9) in
+    :footcite:p:`andersson_non-parametric_2015`:
 
     .. math::
         \begin{equation}
@@ -514,7 +572,8 @@ def spherical_covariance(theta: np.ndarray, a: float) -> np.ndarray:
     r"""
     Compute the spherical covariance for given distances and scale parameter.
 
-    Implements :math:`C_{\theta}`, following Eq. (10) in :footcite:p:`andersson_non-parametric_2015`:
+    Implements :math:`C_{\theta}`, following Eq. (10) in
+    :footcite:p:`andersson_non-parametric_2015`:
 
     .. math::
         \begin{equation}
@@ -558,8 +617,9 @@ def compute_pairwise_angles(
 ) -> np.ndarray:
     r"""Compute pairwise angles across diffusion gradient encoding directions.
 
-    Following :footcite:p:`andersson_non-parametric_2015`:, it computes the smallest of the angles between
-    each pair if ``closest_polarity`` is :obj:`True`, i.e.,
+    Following :footcite:p:`andersson_non-parametric_2015`, it computes the
+    smallest of the angles between each pair if ``closest_polarity`` is ``True``,
+    i.e.,
 
     .. math::
 

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -41,6 +41,16 @@ from sklearn.gaussian_process.kernels import (
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.utils._param_validation import Interval, StrOptions
 
+__all__ = [
+    "DiffusionGPR",
+    "ExponentialKriging",
+    "SphericalKriging",
+    "MultiShellKernel",
+    "exponential_covariance",
+    "spherical_covariance",
+    "compute_pairwise_angles",
+]
+
 BOUNDS_A: tuple[float, float] = (0.1, 2.35)
 """The limits for the parameter *a* (angular distance in rad)."""
 BOUNDS_LAMBDA: tuple[float, float] = (1e-3, 1000)
@@ -66,6 +76,13 @@ SUPPORTED_OPTIMIZERS = set(CONFIGURABLE_OPTIONS.keys()) | {"fmin_l_bfgs_b"}
 
 UNKNOWN_OPTIMIZER_ERROR_MSG = "Unknown optimizer {optimizer}."
 """Unknown optimizer error message."""
+
+NONPOSITIVE_BVAL_ERROR_MSG = (
+    "MultiShellKernel requires strictly positive b-values (the radial covariance "
+    "is a squared-exponential on log-b); b0/non-positive volumes must be excluded "
+    "before fitting."
+)
+"""Error raised when a non-positive b-value reaches the multi-shell kernel."""
 
 
 class DiffusionGPR(GaussianProcessRegressor):
@@ -114,9 +131,10 @@ class DiffusionGPR(GaussianProcessRegressor):
         Hence, that was the method we used for all optimisations in the present
         paper.
 
-    **Multi-shell regression (TODO).**
-    For multi-shell modeling, the kernel :math:`k(\textbf{x}, \textbf{x'})`
-    is updated following Eq. (14) in :footcite:p:`andersson_non-parametric_2015`.
+    **Multi-shell regression.**
+    For multi-shell modeling, use :obj:`~nifreeze.model.gpr.MultiShellKernel`,
+    which updates the kernel :math:`k(\textbf{x}, \textbf{x'})` following Eq. (14)
+    in :footcite:p:`andersson_non-parametric_2015`.
 
     .. math::
         k(\textbf{x}, \textbf{x'}) = C_{\theta}(\mathbf{g}, \mathbf{g'}; a) C_{b}(|b - b'|; \ell)
@@ -437,7 +455,9 @@ class SphericalKriging(Kernel):
         if not eval_gradient:
             return self.beta_l * C_theta
 
-        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter.
+        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
+        # (``Kernel.theta`` is log-transformed), hence the chain-rule factors of
+        # ``beta_a`` and ``beta_l``.
         deriv_a = np.zeros_like(thetas)
         nonzero = thetas <= self.beta_a
         deriv_a[nonzero] = (
@@ -477,7 +497,33 @@ class SphericalKriging(Kernel):
 
 
 class MultiShellKernel(KernelOperator):
-    """Composite kernel for multi-shell diffusion data."""
+    r"""Composite kernel for multi-shell diffusion data.
+
+    Implements the multi-shell covariance of :footcite:p:`andersson_non-parametric_2015`
+    (Eq. 14) as the product of an angular (orientation) kernel and a radial
+    (b-value) kernel,
+
+    .. math::
+        k(\mathbf{x}, \mathbf{x'}) =
+        C_{\theta}(\mathbf{g}, \mathbf{g'}; a)\, C_{b}(b, b'; \ell),
+
+    where the design matrix ``X`` is expected to hold the diffusion-encoding
+    gradient components in ``orientation_dims`` and the b-value in ``bval_index``
+    (default layout ``[gx, gy, gz, bval]``). The default ``radial_kernel``
+    (:obj:`~sklearn.gaussian_process.kernels.RBF`) applied to :math:`\log b`
+    reproduces Eq. (15),
+
+    .. math::
+        C_{b}(b, b'; \ell) = \exp\!\left(-\frac{(\log b - \log b')^2}{2\ell^2}\right).
+
+    The b-value column must be strictly positive: :math:`\log b` is undefined for
+    b0 volumes, which must be handled/excluded upstream.
+
+    References
+    ----------
+    .. footbibliography::
+
+    """
 
     k1: Kernel
     k2: Kernel
@@ -499,20 +545,50 @@ class MultiShellKernel(KernelOperator):
 
         super().__init__(self.orientation_kernel, self.radial_kernel)
 
-    def get_params(self, deep: bool = True):  # noqa: D401
-        # Return only __init__ parameters (sklearn clone() relies on this)
-        return {
+    def get_params(self, deep: bool = True) -> dict:
+        # ``clone()`` calls ``get_params(deep=False)`` and re-invokes ``__init__``,
+        # so the shallow keys must match the constructor signature (not the
+        # inherited ``k1``/``k2``). With ``deep=True`` we also surface the
+        # sub-kernels' parameters, keeping ``get_params``/``set_params`` and
+        # ``hyperparameters`` consistent under the constructor's names.
+        params: dict = {
             "orientation_kernel": self.orientation_kernel,
             "radial_kernel": self.radial_kernel,
             "orientation_dims": self.orientation_dims,
             "bval_index": self.bval_index,
         }
+        if deep:
+            for prefix, kernel in (
+                ("orientation_kernel", self.orientation_kernel),
+                ("radial_kernel", self.radial_kernel),
+            ):
+                params.update(
+                    (f"{prefix}__{name}", value) for name, value in kernel.get_params().items()
+                )
+        return params
+
+    @property
+    def hyperparameters(self) -> list[Hyperparameter]:
+        """Expose sub-kernel hyperparameters under the constructor's names."""
+        r = []
+        for prefix, kernel in (
+            ("orientation_kernel", self.orientation_kernel),
+            ("radial_kernel", self.radial_kernel),
+        ):
+            for hp in kernel.hyperparameters:
+                r.append(
+                    Hyperparameter(f"{prefix}__{hp.name}", hp.value_type, hp.bounds, hp.n_elements)
+                )
+        return r
 
     def _split(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         X = np.asarray(X)
+        bvals = X[:, self.bval_index]
+        if np.any(bvals <= 0):
+            raise ValueError(NONPOSITIVE_BVAL_ERROR_MSG)
         orient = X[:, self.orientation_dims]
-        bvals = np.log(X[:, self.bval_index]).reshape(-1, 1)
-        return orient, bvals
+        log_bvals = np.log(bvals).reshape(-1, 1)
+        return orient, log_bvals
 
     def __call__(
         self,

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -1311,3 +1311,13 @@ def test_gp_model_multishell_rejects_b0():
     gp = GaussianProcessModel(kernel_model="multishell")
     with pytest.raises(ValueError, match="strictly positive b-values"):
         gp.fit(signal, X)
+
+
+def test_btable_asarray_promotes_1d_input():
+    """A single 1-D gradient row is promoted to a (1, n) design matrix."""
+    from nifreeze.model._dipy import _btable_asarray
+
+    x = np.array([1.0, 0.0, 0.0, 1000.0])
+    out = _btable_asarray(x)
+    assert out.shape == (1, 4)
+    assert np.allclose(out, x[np.newaxis, :])

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -1272,6 +1272,7 @@ def test_gp_model(evals, S0, snr, hsph_dirs, bval_shell):
     assert prediction.shape == (2,)
 
 
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("hsph_dirs", (30, 20))
 def test_gp_model_multishell(hsph_dirs):
     """GaussianProcessModel wires MultiShellKernel end-to-end over two shells."""

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -43,6 +43,7 @@ from nifreeze.data.dmri.utils import (
 from nifreeze.model._dipy import GaussianProcessModel
 from nifreeze.model.base import MASK_ABSENCE_WARN_MSG
 from nifreeze.model.dki import DiffusionKurtosisModel as _NFDKIModel
+from nifreeze.model.gpr import MultiShellKernel
 from nifreeze.testing import simulations as _sim
 
 B_MATRIX = np.array(
@@ -1269,3 +1270,43 @@ def test_gp_model(evals, S0, snr, hsph_dirs, bval_shell):
     prediction = gpfit.predict(gtab.bvecs[-2:])
 
     assert prediction.shape == (2,)
+
+
+@pytest.mark.parametrize("hsph_dirs", (30, 20))
+def test_gp_model_multishell(hsph_dirs):
+    """GaussianProcessModel wires MultiShellKernel end-to-end over two shells."""
+    evecs = _sim.create_single_fiber_evecs()
+    evals = (0.0015, 0.0003, 0.0003)
+
+    # Build a 2-shell gradient table (drop the leading b0 of each shell).
+    gtabs = [_sim.create_single_shell_gradient_table(hsph_dirs, b)[1:] for b in (1000, 2000)]
+    bvals = np.concatenate([g.bvals for g in gtabs])
+    bvecs = np.concatenate([g.bvecs for g in gtabs])
+    gtab = gradient_table_from_bvals_bvecs(bvals, bvecs)
+    signal = single_tensor(gtab, S0=100, evals=evals, evecs=evecs, snr=20)
+
+    # The multi-shell kernel needs the b-value, so feed [gx, gy, gz, bval].
+    X = np.column_stack([bvecs, bvals])
+
+    gp = GaussianProcessModel(kernel_model="multishell")
+    assert isinstance(gp.kernel, MultiShellKernel)
+
+    # Fit on all but the last two directions, predict those two (LOVO-style).
+    gpfit = gp.fit(signal[:-2], X[:-2])
+    prediction = gpfit.predict(X[-2:])
+
+    assert prediction.shape == (2,)
+    assert np.isfinite(prediction).all()
+
+
+def test_gp_model_multishell_rejects_b0():
+    """A b0 (bval=0) in the training data must raise, not emit inf/nan."""
+    gtab = _sim.create_single_shell_gradient_table(20, 1000)  # keeps the leading b0
+    evecs = _sim.create_single_fiber_evecs()
+    signal = single_tensor(gtab, S0=100, evals=(0.0015, 0.0003, 0.0003), evecs=evecs, snr=20)
+
+    X = np.column_stack([gtab.bvecs, gtab.bvals])  # first row is the b0 (bval=0)
+
+    gp = GaussianProcessModel(kernel_model="multishell")
+    with pytest.raises(ValueError, match="strictly positive b-values"):
+        gp.fit(signal, X)

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -24,6 +24,7 @@
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
+from sklearn.base import clone
 
 from nifreeze.model import gpr
 
@@ -584,3 +585,30 @@ def test_multishellkernel_nonpositive_bval(bad_bval, match):
     with pytest.warns(RuntimeWarning, match=match):
         # Current behavior: log(bval) -inf/nan propagates into K
         k(X)
+
+
+def test_multishellkernel_cloneable():
+    k = gpr.MultiShellKernel()
+    k2 = clone(k)
+    assert isinstance(k2, gpr.MultiShellKernel)
+
+
+@pytest.mark.parametrize("n_samples", [8])
+def test_multishellkernel_gp(n_samples):
+    """Smoke test: DiffusionGPR can fit/predict with MultiShellKernel."""
+    X = _make_multishell_X(n_samples)
+    y = np.linspace(1.0, 0.5, num=n_samples, dtype=float)
+
+    model = gpr.DiffusionGPR(
+        kernel=gpr.MultiShellKernel(),
+        alpha=1e-6,
+        optimizer=None,  # avoid expensive/unstable hyperparameter optimization in tests
+        disp=False,
+    )
+    model.fit(X, y)
+
+    mean, std = model.predict(X[:2], return_std=True)
+    assert mean.shape == (2,)
+    assert std.shape == (2,)
+    assert np.isfinite(mean).all()
+    assert np.isfinite(std).all()

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -26,7 +26,6 @@ from typing import cast
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
-from sklearn.base import clone
 
 from nifreeze.model import gpr
 
@@ -587,12 +586,6 @@ def test_multishellkernel_nonpositive_bval(bad_bval, match):
     with pytest.warns(RuntimeWarning, match=match):
         # Current behavior: log(bval) -inf/nan propagates into K
         k(X)
-
-
-def test_multishellkernel_cloneable():
-    k = gpr.MultiShellKernel()
-    k2 = clone(k)
-    assert isinstance(k2, gpr.MultiShellKernel)
 
 
 @pytest.mark.parametrize("n_samples", [8])

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -21,6 +21,8 @@
 #     https://www.nipreps.org/community/licensing/
 #
 
+from typing import cast
+
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
@@ -525,7 +527,7 @@ def test_multishellkernel_basic(n_samples, eval_gradient):
     assert np.allclose(K, K.T)
     assert np.allclose(np.diagonal(K), k.diag(X))
 
-    K_predict = k(X, X[:1])
+    K_predict = cast(np.ndarray, k(X, X[:1]))
     assert K_predict.shape == (n_samples, 1)
 
 
@@ -564,8 +566,8 @@ def test_multishellkernel_column_selection(orientation_dims, bval_index, nuisanc
     Y = X.copy()
     Y[:, bval_index] *= 1.5
 
-    Kxy0 = k(X, X)   # includes radial similarity at identical bvals
-    Kxy1 = k(X, Y)   # radial similarity with different bvals
+    Kxy0 = k(X, X)  # includes radial similarity at identical bvals
+    Kxy1 = k(X, Y)  # radial similarity with different bvals
 
     assert not np.allclose(Kxy0, Kxy1)
 
@@ -607,7 +609,7 @@ def test_multishellkernel_gp(n_samples):
     )
     model.fit(X, y)
 
-    mean, std = model.predict(X[:2], return_std=True)
+    mean, std = cast(tuple[np.ndarray, np.ndarray], model.predict(X[:2], return_std=True))
     assert mean.shape == (2,)
     assert std.shape == (2,)
     assert np.isfinite(mean).all()

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -145,6 +145,35 @@ def _unit_vectors_nd(n_samples: int, n_features: int) -> np.ndarray:
     return np.eye(n_features, dtype=float)[:n_samples]
 
 
+def _make_multishell_X(n_samples: int) -> np.ndarray:
+    """Create X = [gx, gy, gz, bval] for MultiShellKernel tests (deterministic).
+
+    We do not require orthogonality (and cannot have >3 orthogonal vectors in R^3).
+    We just need unit vectors with some diversity.
+    """
+    dirs = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, -1.0],
+        ],
+        dtype=float,
+    )
+    dirs /= np.linalg.norm(dirs, axis=1, keepdims=True)
+    orient = dirs[np.arange(n_samples) % dirs.shape[0], :]
+
+    shells = np.array([1000.0, 2000.0, 3000.0], dtype=float)
+    bvals = shells[np.arange(n_samples) % shells.size].reshape(-1, 1)
+
+    return np.hstack((orient, bvals))
+
+
 # No need to use normalized vectors: compute_pairwise_angles takes care of it.
 # The [-1, 0, 1].T vector serves as a case where e.g. the angle between vector
 # [1, 0, 0] and the former is 135 unless the closest polarity flag is set to
@@ -475,3 +504,83 @@ def test_spherical_kriging_basic(
     d = sk.diag(X)
     assert d.shape == (n_samples,)
     assert np.allclose(d, sk.beta_l * np.ones(n_samples))
+
+
+@pytest.mark.parametrize("n_samples", [3, 5])
+@pytest.mark.parametrize("eval_gradient", [False, True])
+def test_multishellkernel_basic(n_samples, eval_gradient):
+    k = gpr.MultiShellKernel()
+    X = _make_multishell_X(n_samples)
+
+    if eval_gradient:
+        K, grad = k(X, eval_gradient=True)
+        assert grad.shape == (n_samples, n_samples, len(k.theta))
+        assert np.isfinite(grad).all()
+    else:
+        K = k(X, eval_gradient=False)
+
+    assert K.shape == (n_samples, n_samples)
+    assert np.isfinite(K).all()
+    assert np.allclose(K, K.T)
+    assert np.allclose(np.diagonal(K), k.diag(X))
+
+    K_predict = k(X, X[:1])
+    assert K_predict.shape == (n_samples, 1)
+
+
+@pytest.mark.parametrize(
+    "orientation_dims, bval_index, nuisance_index",
+    [
+        ((0, 1, 2), 3, 4),
+        ((1, 2, 3), 0, 4),
+    ],
+)
+def test_multishellkernel_column_selection(orientation_dims, bval_index, nuisance_index):
+    """Ensure MultiShellKernel uses only the configured orientation and bval columns.
+
+    Changes to unused (nuisance) columns must not affect the kernel, while changes
+    to the bval column (and/or orientation columns) must affect it.
+    """
+    n_samples = 3
+    X = np.zeros((n_samples, 5), dtype=float)
+
+    orient = _unit_vectors_nd(n_samples, 3)
+    X[:, list(orientation_dims)] = orient
+    X[:, bval_index] = np.array([1000.0, 2000.0, 3000.0], dtype=float)
+    X[:, nuisance_index] = np.array([10.0, 11.0, 12.0], dtype=float)
+
+    k = gpr.MultiShellKernel(orientation_dims=orientation_dims, bval_index=bval_index)
+
+    # Nuisance columns must not matter (test on K(X) is fine)
+    K0 = k(X)
+    Xn = X.copy()
+    Xn[:, nuisance_index] += 1000.0
+    assert np.allclose(K0, k(Xn))
+
+    # To demonstrate bvals matter, compare K(X, Y) where orientations are identical
+    # but bvals differ. This makes the orientation kernel a constant 1 for each pair,
+    # so differences come from the radial kernel.
+    Y = X.copy()
+    Y[:, bval_index] *= 1.5
+
+    Kxy0 = k(X, X)   # includes radial similarity at identical bvals
+    Kxy1 = k(X, Y)   # radial similarity with different bvals
+
+    assert not np.allclose(Kxy0, Kxy1)
+
+
+@pytest.mark.parametrize(
+    ("bad_bval", "match"),
+    [
+        (0.0, "divide by zero"),
+        (-1.0, "invalid value"),
+    ],
+)
+def test_multishellkernel_nonpositive_bval(bad_bval, match):
+    k = gpr.MultiShellKernel()
+    X = _make_multishell_X(3)
+    X[0, 3] = bad_bval
+
+    with pytest.warns(RuntimeWarning, match=match):
+        # Current behavior: log(bval) -inf/nan propagates into K
+        k(X)

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -24,6 +24,7 @@
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
+from sklearn.base import clone
 
 from nifreeze.model import gpr
 
@@ -646,3 +647,30 @@ def test_multishellkernel_nonpositive_bval(bad_bval, match):
     with pytest.warns(RuntimeWarning, match=match):
         # Current behavior: log(bval) -inf/nan propagates into K
         k(X)
+
+
+def test_multishellkernel_cloneable():
+    k = gpr.MultiShellKernel()
+    k2 = clone(k)
+    assert isinstance(k2, gpr.MultiShellKernel)
+
+
+@pytest.mark.parametrize("n_samples", [8])
+def test_multishellkernel_gp(n_samples):
+    """Smoke test: DiffusionGPR can fit/predict with MultiShellKernel."""
+    X = _make_multishell_X(n_samples)
+    y = np.linspace(1.0, 0.5, num=n_samples, dtype=float)
+
+    model = gpr.DiffusionGPR(
+        kernel=gpr.MultiShellKernel(),
+        alpha=1e-6,
+        optimizer=None,  # avoid expensive/unstable hyperparameter optimization in tests
+        disp=False,
+    )
+    model.fit(X, y)
+
+    mean, std = model.predict(X[:2], return_std=True)
+    assert mean.shape == (2,)
+    assert std.shape == (2,)
+    assert np.isfinite(mean).all()
+    assert np.isfinite(std).all()

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -523,32 +523,6 @@ _ORIENT = np.array(
 _ORIENT /= np.linalg.norm(_ORIENT, axis=1, keepdims=True)
 
 
-def _numeric_kernel_gradient(kernel, X, eps: float = 1e-6) -> np.ndarray:
-    """Finite-difference gradient of K(X) w.r.t. the (log-space) kernel theta."""
-    from sklearn.base import clone
-
-    theta = kernel.theta
-    _, analytic = kernel(X, eval_gradient=True)
-    numeric = np.zeros_like(analytic)
-    for i in range(len(theta)):
-        tp, tm = theta.copy(), theta.copy()
-        tp[i] += eps
-        tm[i] -= eps
-        kp, km = clone(kernel), clone(kernel)
-        kp.theta = tp
-        km.theta = tm
-        numeric[..., i] = (kp(X) - km(X)) / (2 * eps)
-    return numeric
-
-
-@pytest.mark.parametrize("kernel", [gpr.SphericalKriging(), gpr.ExponentialKriging()])
-def test_kernel_gradient_matches_finite_differences(kernel):
-    """Analytical gradients must match numerical ones (sklearn's log-hyperparameter space)."""
-    _, analytic = kernel(_ORIENT, eval_gradient=True)
-    numeric = _numeric_kernel_gradient(kernel, _ORIENT)
-    assert np.allclose(analytic, numeric, atol=1e-5)
-
-
 def test_gp_model_adds_and_optimizes_whitekernel():
     """GaussianProcessModel folds noise into a WhiteKernel that is tuned by the optimizer."""
     from sklearn.gaussian_process.kernels import Sum, WhiteKernel
@@ -739,6 +713,7 @@ def test_multishellkernel_gp(n_samples):
     assert np.isfinite(std).all()
 
 
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("n_samples", [12])
 def test_multishellkernel_gp_optimizes(n_samples):
     """The gradient-based optimizer path runs and tunes theta with MultiShellKernel."""

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -21,6 +21,8 @@
 #     https://www.nipreps.org/community/licensing/
 #
 
+from typing import cast
+
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
@@ -587,7 +589,7 @@ def test_multishellkernel_basic(n_samples, eval_gradient):
     assert np.allclose(K, K.T)
     assert np.allclose(np.diagonal(K), k.diag(X))
 
-    K_predict = k(X, X[:1])
+    K_predict = cast(np.ndarray, k(X, X[:1]))
     assert K_predict.shape == (n_samples, 1)
 
 
@@ -626,8 +628,8 @@ def test_multishellkernel_column_selection(orientation_dims, bval_index, nuisanc
     Y = X.copy()
     Y[:, bval_index] *= 1.5
 
-    Kxy0 = k(X, X)   # includes radial similarity at identical bvals
-    Kxy1 = k(X, Y)   # radial similarity with different bvals
+    Kxy0 = k(X, X)  # includes radial similarity at identical bvals
+    Kxy1 = k(X, Y)  # radial similarity with different bvals
 
     assert not np.allclose(Kxy0, Kxy1)
 
@@ -669,7 +671,7 @@ def test_multishellkernel_gp(n_samples):
     )
     model.fit(X, y)
 
-    mean, std = model.predict(X[:2], return_std=True)
+    mean, std = cast(tuple[np.ndarray, np.ndarray], model.predict(X[:2], return_std=True))
     assert mean.shape == (2,)
     assert std.shape == (2,)
     assert np.isfinite(mean).all()

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -692,6 +692,32 @@ def test_multishellkernel_clone_theta_roundtrip():
     assert np.allclose(k.theta, theta)
 
 
+def test_multishellkernel_get_params_deep():
+    """``get_params(deep=True)`` surfaces the sub-kernels' parameters (prefixed)."""
+    k = gpr.MultiShellKernel()
+
+    shallow = k.get_params(deep=False)
+    assert set(shallow) == {
+        "orientation_kernel",
+        "radial_kernel",
+        "orientation_dims",
+        "bval_index",
+    }
+
+    deep = k.get_params(deep=True)
+    # Shallow keys are still present, plus prefixed sub-kernel parameters.
+    assert set(shallow).issubset(deep)
+    assert any(key.startswith("orientation_kernel__") for key in deep)
+    assert any(key.startswith("radial_kernel__") for key in deep)
+
+
+def test_multishellkernel_repr():
+    """``repr`` mentions the composed sub-kernels."""
+    text = repr(gpr.MultiShellKernel())
+    assert text.startswith("MultiShellKernel(")
+    assert "*" in text
+
+
 @pytest.mark.parametrize("n_samples", [8])
 def test_multishellkernel_gp(n_samples):
     """Smoke test: DiffusionGPR can fit/predict with MultiShellKernel."""

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -145,6 +145,35 @@ def _unit_vectors_nd(n_samples: int, n_features: int) -> np.ndarray:
     return np.eye(n_features, dtype=float)[:n_samples]
 
 
+def _make_multishell_X(n_samples: int) -> np.ndarray:
+    """Create X = [gx, gy, gz, bval] for MultiShellKernel tests (deterministic).
+
+    We do not require orthogonality (and cannot have >3 orthogonal vectors in R^3).
+    We just need unit vectors with some diversity.
+    """
+    dirs = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, -1.0],
+        ],
+        dtype=float,
+    )
+    dirs /= np.linalg.norm(dirs, axis=1, keepdims=True)
+    orient = dirs[np.arange(n_samples) % dirs.shape[0], :]
+
+    shells = np.array([1000.0, 2000.0, 3000.0], dtype=float)
+    bvals = shells[np.arange(n_samples) % shells.size].reshape(-1, 1)
+
+    return np.hstack((orient, bvals))
+
+
 # No need to use normalized vectors: compute_pairwise_angles takes care of it.
 # The [-1, 0, 1].T vector serves as a case where e.g. the angle between vector
 # [1, 0, 0] and the former is 135 unless the closest polarity flag is set to
@@ -537,3 +566,83 @@ def test_gp_model_adds_and_optimizes_whitekernel():
     prediction = gpfit.predict(_ORIENT[:2])
     assert prediction.shape == (2,)
     assert np.isfinite(prediction).all()
+
+
+@pytest.mark.parametrize("n_samples", [3, 5])
+@pytest.mark.parametrize("eval_gradient", [False, True])
+def test_multishellkernel_basic(n_samples, eval_gradient):
+    k = gpr.MultiShellKernel()
+    X = _make_multishell_X(n_samples)
+
+    if eval_gradient:
+        K, grad = k(X, eval_gradient=True)
+        assert grad.shape == (n_samples, n_samples, len(k.theta))
+        assert np.isfinite(grad).all()
+    else:
+        K = k(X, eval_gradient=False)
+
+    assert K.shape == (n_samples, n_samples)
+    assert np.isfinite(K).all()
+    assert np.allclose(K, K.T)
+    assert np.allclose(np.diagonal(K), k.diag(X))
+
+    K_predict = k(X, X[:1])
+    assert K_predict.shape == (n_samples, 1)
+
+
+@pytest.mark.parametrize(
+    "orientation_dims, bval_index, nuisance_index",
+    [
+        ((0, 1, 2), 3, 4),
+        ((1, 2, 3), 0, 4),
+    ],
+)
+def test_multishellkernel_column_selection(orientation_dims, bval_index, nuisance_index):
+    """Ensure MultiShellKernel uses only the configured orientation and bval columns.
+
+    Changes to unused (nuisance) columns must not affect the kernel, while changes
+    to the bval column (and/or orientation columns) must affect it.
+    """
+    n_samples = 3
+    X = np.zeros((n_samples, 5), dtype=float)
+
+    orient = _unit_vectors_nd(n_samples, 3)
+    X[:, list(orientation_dims)] = orient
+    X[:, bval_index] = np.array([1000.0, 2000.0, 3000.0], dtype=float)
+    X[:, nuisance_index] = np.array([10.0, 11.0, 12.0], dtype=float)
+
+    k = gpr.MultiShellKernel(orientation_dims=orientation_dims, bval_index=bval_index)
+
+    # Nuisance columns must not matter (test on K(X) is fine)
+    K0 = k(X)
+    Xn = X.copy()
+    Xn[:, nuisance_index] += 1000.0
+    assert np.allclose(K0, k(Xn))
+
+    # To demonstrate bvals matter, compare K(X, Y) where orientations are identical
+    # but bvals differ. This makes the orientation kernel a constant 1 for each pair,
+    # so differences come from the radial kernel.
+    Y = X.copy()
+    Y[:, bval_index] *= 1.5
+
+    Kxy0 = k(X, X)   # includes radial similarity at identical bvals
+    Kxy1 = k(X, Y)   # radial similarity with different bvals
+
+    assert not np.allclose(Kxy0, Kxy1)
+
+
+@pytest.mark.parametrize(
+    ("bad_bval", "match"),
+    [
+        (0.0, "divide by zero"),
+        (-1.0, "invalid value"),
+    ],
+)
+def test_multishellkernel_nonpositive_bval(bad_bval, match):
+    k = gpr.MultiShellKernel()
+    X = _make_multishell_X(3)
+    X[0, 3] = bad_bval
+
+    with pytest.warns(RuntimeWarning, match=match):
+        # Current behavior: log(bval) -inf/nan propagates into K
+        k(X)

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -26,6 +26,7 @@ from typing import cast
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
+from sklearn.gaussian_process.kernels import RBF
 
 from nifreeze.model import gpr
 
@@ -633,21 +634,88 @@ def test_multishellkernel_column_selection(orientation_dims, bval_index, nuisanc
     assert not np.allclose(Kxy0, Kxy1)
 
 
-@pytest.mark.parametrize(
-    ("bad_bval", "match"),
-    [
-        (0.0, "divide by zero"),
-        (-1.0, "invalid value"),
-    ],
-)
-def test_multishellkernel_nonpositive_bval(bad_bval, match):
+@pytest.mark.parametrize("bad_bval", [0.0, -1.0])
+def test_multishellkernel_nonpositive_bval(bad_bval):
+    """Non-positive b-values (e.g. b0) must be rejected, not silently -inf/nan."""
     k = gpr.MultiShellKernel()
     X = _make_multishell_X(3)
     X[0, 3] = bad_bval
 
-    with pytest.warns(RuntimeWarning, match=match):
-        # Current behavior: log(bval) -inf/nan propagates into K
+    with pytest.raises(ValueError, match="strictly positive b-values"):
         k(X)
+
+
+def _numeric_kernel_gradient(kernel, X, eps: float = 1e-6) -> np.ndarray:
+    """Finite-difference gradient of K(X) w.r.t. the (log-space) kernel theta."""
+    from sklearn.base import clone
+
+    theta = kernel.theta
+    _, analytic = kernel(X, eval_gradient=True)
+    numeric = np.zeros_like(analytic)
+    for i in range(len(theta)):
+        tp, tm = theta.copy(), theta.copy()
+        tp[i] += eps
+        tm[i] -= eps
+        kp, km = clone(kernel), clone(kernel)
+        kp.theta = tp
+        km.theta = tm
+        numeric[..., i] = (kp(X) - km(X)) / (2 * eps)
+    return numeric
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        gpr.SphericalKriging(),
+        gpr.ExponentialKriging(),
+        gpr.MultiShellKernel(),
+        gpr.MultiShellKernel(orientation_kernel=gpr.ExponentialKriging()),
+    ],
+)
+def test_kernel_gradient_matches_finite_differences(kernel):
+    """Analytical gradients must match numerical ones (log-space, as sklearn expects)."""
+    orient = _make_multishell_X(5)[:, :3]
+    if isinstance(kernel, gpr.MultiShellKernel):
+        X = _make_multishell_X(5)
+    else:
+        X = orient
+
+    _, analytic = kernel(X, eval_gradient=True)
+    numeric = _numeric_kernel_gradient(kernel, X)
+    assert np.allclose(analytic, numeric, atol=1e-5)
+
+
+def test_multishellkernel_reduces_to_radial_when_orientations_identical():
+    """With identical orientations, K = lambda * C_b(log b) (Andersson Eq. 15)."""
+    n = 4
+    orient = np.tile([1.0, 0.0, 0.0], (n, 1))
+    bvals = np.array([1000.0, 2000.0, 3000.0, 1000.0])
+    X = np.column_stack([orient, bvals])
+
+    lam, ell = 0.7, 1.3
+    k = gpr.MultiShellKernel(
+        orientation_kernel=gpr.SphericalKriging(beta_l=lam),
+        radial_kernel=RBF(length_scale=ell),
+    )
+    K = cast(np.ndarray, k(X))
+
+    logb = np.log(bvals)
+    C_b = np.exp(-((logb[:, None] - logb[None, :]) ** 2) / (2 * ell**2))
+    assert np.allclose(K, lam * C_b)
+
+
+def test_multishellkernel_clone_theta_roundtrip():
+    """clone_with_theta must preserve structure and set sub-kernel hyperparameters."""
+    k = gpr.MultiShellKernel()
+    theta = k.theta
+    new_theta = theta + 0.1
+    k2 = k.clone_with_theta(new_theta)
+
+    assert isinstance(k2, gpr.MultiShellKernel)
+    assert np.allclose(k2.theta, new_theta)
+    assert k2.bounds.shape == k.bounds.shape
+    # The original kernel is untouched (clone semantics).
+    assert np.allclose(k.theta, theta)
 
 
 @pytest.mark.parametrize("n_samples", [8])
@@ -669,3 +737,28 @@ def test_multishellkernel_gp(n_samples):
     assert std.shape == (2,)
     assert np.isfinite(mean).all()
     assert np.isfinite(std).all()
+
+
+@pytest.mark.parametrize("n_samples", [12])
+def test_multishellkernel_gp_optimizes(n_samples):
+    """The gradient-based optimizer path runs and tunes theta with MultiShellKernel."""
+    X = _make_multishell_X(n_samples)
+    rng = np.random.default_rng(42)
+    y = X[:, 3] / 3000.0 + 0.05 * rng.standard_normal(n_samples)
+
+    kernel = gpr.MultiShellKernel()
+    theta0 = kernel.theta.copy()
+    model = gpr.DiffusionGPR(
+        kernel=kernel,
+        alpha=1e-3,
+        optimizer="fmin_l_bfgs_b",
+        eval_gradient=True,
+        maxiter=50,
+    )
+    model.fit(X, y)
+
+    # Optimizer actually moved the hyperparameters and produced a valid fit.
+    assert not np.allclose(model.kernel_.theta, theta0)
+    mean = cast(np.ndarray, model.predict(X[:3]))
+    assert mean.shape == (3,)
+    assert np.isfinite(mean).all()

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -26,7 +26,6 @@ from typing import cast
 import numpy as np
 import pytest
 from dipy.io import read_bvals_bvecs
-from sklearn.base import clone
 
 from nifreeze.model import gpr
 
@@ -649,12 +648,6 @@ def test_multishellkernel_nonpositive_bval(bad_bval, match):
     with pytest.warns(RuntimeWarning, match=match):
         # Current behavior: log(bval) -inf/nan propagates into K
         k(X)
-
-
-def test_multishellkernel_cloneable():
-    k = gpr.MultiShellKernel()
-    k2 = clone(k)
-    assert isinstance(k2, gpr.MultiShellKernel)
 
 
 @pytest.mark.parametrize("n_samples", [8])


### PR DESCRIPTION
## Summary

Adds a `MultiShellKernel` so a single Gaussian process can model **multi-shell** diffusion data, following Andersson & Sotiropoulos (2015). The kernel is the product of an angular (orientation) covariance and a radial (log-b) covariance (Eqs. 14–15), letting the GP borrow strength across shells instead of fitting each shell independently.

It plugs into the existing GP path: `GaussianProcessModel(kernel_model="multishell")` builds a spherical angular × RBF-on-log-b radial kernel. The design matrix now carries the b-value (`[gx, gy, gz, bval]`), which the multi-shell kernel selects internally; single-shell kernels drop that column and keep consuming orientations only.

## Depends on the GP kernel/noise fix (#457, fixes #456)

This is rebased on top of #457 and relies on it:

- `MultiShellKernel` returns **analytical gradients in scikit-learn's log-hyperparameter space**, the same convention #457 corrected for the single-shell kernels; the gradient-based optimizer would otherwise be inconsistent across the angular and radial factors.
- Measurement noise is tuned through the `WhiteKernel` term introduced in #457, and the multi-shell path fits through that same flow.

## Tests

- **Kernel correctness** — `test_multishellkernel_basic` (shape, symmetry, `diag` consistency, gradient shape), `test_multishellkernel_reduces_to_radial_when_orientations_identical` (reduces to the radial kernel, Eq. 15, when orientations match), and `test_multishellkernel_column_selection` (only the configured orientation/b-value columns affect the result).
- **Analytical gradients** — `test_kernel_gradient_matches_finite_differences` now also covers `MultiShellKernel`, checking analytical vs. finite-difference gradients in log space.
- **Guards** — `test_multishellkernel_nonpositive_bval` and `test_gp_model_multishell_rejects_b0` ensure b0 / non-positive b-values are rejected rather than producing `-inf`/`nan`.
- **Cloning** — `test_multishellkernel_clone_theta_roundtrip` verifies `clone_with_theta` preserves structure.
- **End-to-end** — `test_multishellkernel_gp`, `test_multishellkernel_gp_optimizes`, and `test_gp_model_multishell` fit and predict through `DiffusionGPR` / `GaussianProcessModel` over two shells.
