### PR TITLE
REF: Reuse path variable in BOLD notebook

### DIFF
--- a/docs/notebooks/bold_realignment.ipynb
+++ b/docs/notebooks/bold_realignment.ipynb
@@ -38,7 +38,7 @@
     "WORKDIR = Path.home() / \"tmp\" / \"nifreezedev\" / \"ismrm25\"\n",
     "WORKDIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "OUTPUT_DIR = Path.home() / \"tmp\" / \"nifreezedev\" / \"ismrm25\" / \"nifreeze-ismrm25-exp2\"\n",
+    "OUTPUT_DIR = WORKDIR / \"nifreeze-ismrm25-exp2\"\n",
     "OUTPUT_DIR.mkdir(exist_ok=True, parents=True)"
    ]
   },


### PR DESCRIPTION
Reuse path variable in BOLD notebook for the sake of compactness.