### PR TITLE
DOC: Improve instructions for required external dependencies

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,4 +17,9 @@ Check your installation with the following command line ::
 
 External Dependencies
 ---------------------
-*nifreeze* requires DIPY_, and ANTs_.
+*nifreeze* requires ANTs_, which is leveraged through the Nipype_ Python
+interface for registration purposes. There are
+[several ways to install ``ANTs``](https://github.com/ANTsX/ANTs?tab=readme-ov-file#installation).
+Notably, the path to the installed binaries needs to be added to the ``PATH`` ::
+
+   $ export PATH=/path/to/ants/bin:$PATH


### PR DESCRIPTION
Improve instructions for required external dependencies:
- Remove `DIPY` from the external dependency list: it is listed as a dependency in `pyproject.toml`.
- Add details about how `ANTs` is used and provide the necessary information for a successful installation in the context of `NiFreeze`.