### PR TITLE
REF: Reorder import statements in PET notebook

### DIFF
--- a/docs/notebooks/pet_motion_estimation.ipynb
+++ b/docs/notebooks/pet_motion_estimation.ipynb
@@ -10,19 +10,8 @@
     "from os import getenv\n",
     "from pathlib import Path\n",
     "\n",
-    "import nibabel as nib\n",
+    "from nifreeze.data.pet import PET\n",
     "\n",
-    "from nifreeze.data import pet\n",
-    "from nifreeze.model import PETModel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "68dc04bd-04d8-49fa-bb21-d5de76afbc63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Install test data from gin.g-node.org:\n",
     "#   $ datalad install -g https://gin.g-node.org/nipreps-data/tests-nifreeze.git\n",
     "# and point the environment variable TEST_DATA_HOME to the corresponding folder\n",
@@ -40,7 +29,7 @@
     "    DATA_PATH / \"pet_data\" / \"sub-02\" / \"ses-baseline\" / \"pet\" / \"sub-02_ses-baseline_pet.json\"\n",
     ")\n",
     "\n",
-    "pet_dataset = pet.PET.load(pet_file, json_file)"
+    "pet_dataset = PET.load(pet_file, json_file)"
    ]
   },
   {
@@ -417,6 +406,8 @@
     }
    ],
    "source": [
+    "from nifreeze.model import PETModel\n",
+    "\n",
     "model = PETModel(dataset=pet_dataset, timepoints=pet_dataset.midframe, xlim=7000)"
    ]
   },
@@ -447,13 +438,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import nibabel as nb\n",
+    "\n",
     "# before\n",
-    "nifti_img_before = nib.Nifti1Image(predicted, pet_dataset.affine)\n",
+    "nifti_img_before = nb.Nifti1Image(predicted, pet_dataset.affine)\n",
     "output_path_before = \"before_mc.nii\"\n",
     "nifti_img_before.to_filename(output_path_before)\n",
     "\n",
     "# after\n",
-    "nifti_img_after = nib.Nifti1Image(data_test[0], pet_dataset.affine)\n",
+    "nifti_img_after = nb.Nifti1Image(data_test[0], pet_dataset.affine)\n",
     "output_path_after = \"after_mc.nii\"\n",
     "nifti_img_after.to_filename(output_path_after)"
    ]
@@ -2249,16 +2242,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "7c2c8811-d7ba-4ad1-8275-abd3b9ac3b10",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from nifreeze.estimator import PETMotionEstimator"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 13,
    "id": "78edfed2-8200-48be-9f58-8fb910fac299",
    "metadata": {},
@@ -2272,6 +2255,8 @@
     }
    ],
    "source": [
+    "from nifreeze.estimator import PETMotionEstimator\n",
+    "\n",
     "# Instantiate with a PETModel or appropriate model instance\n",
     "model = PETModel(\n",
     "    dataset=pet_dataset, timepoints=pet_dataset.midframe, xlim=pet_dataset.total_duration\n",


### PR DESCRIPTION
Reorder import statements in PET notebook: import modules close to the statements where they are actually used and remove unused import statements.

Take advantage of the commit to:
- Import only the required `PET` data class from the `nifreeze.data.pet` module
- Use `nb` as the alias of `nibabel` to increase consistency across the code base.