### PR TITLE
STY: Raise exception if DWI model is not found

### DIFF
--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -132,6 +132,8 @@ class BaseDWIModel(BaseModel):
                 import_module(module_name),
                 class_name,
             )(gtab, **kwargs)
+        else:
+            raise NotImplementedError(f"{model_str} not implemented.")
 
         fit_kwargs: dict[str, Any] = {}  # Add here keyword arguments
 


### PR DESCRIPTION
Raise exception if DWI model is not found.

Fixes:
```
Local variable 'model' might be referenced before assignment
```

raised locally by the IDE.