### PR TITLE
REF: Refactor PET model

### DIFF
--- a/docs/notebooks/pet_motion_estimation.ipynb
+++ b/docs/notebooks/pet_motion_estimation.ipynb
@@ -406,9 +406,9 @@
     }
    ],
    "source": [
-    "from nifreeze.model import PETModel\n",
+    "from nifreeze.model import BSplinePETModel\n",
     "\n",
-    "model = PETModel(dataset=pet_dataset, timepoints=pet_dataset.midframe, xlim=7000)"
+    "model = BSplinePETModel(dataset=pet_dataset)"
    ]
   },
   {
@@ -429,7 +429,7 @@
    "outputs": [],
    "source": [
     "index = 2\n",
-    "predicted = model.fit_predict(pet_dataset.midframe[index])"
+    "predicted = model.fit_predict(index)"
    ]
   },
   {

--- a/src/nifreeze/model/__init__.py
+++ b/src/nifreeze/model/__init__.py
@@ -33,7 +33,7 @@ from nifreeze.model.dmri import (
     DTIModel,
     GPModel,
 )
-from nifreeze.model.pet import PETModel
+from nifreeze.model.pet import BSplinePETModel
 
 __all__ = (
     "ModelFactory",
@@ -43,5 +43,5 @@ __all__ = (
     "DTIModel",
     "GPModel",
     "TrivialModel",
-    "PETModel",
+    "BSplinePETModel",
 )

--- a/src/nifreeze/model/pet.py
+++ b/src/nifreeze/model/pet.py
@@ -22,6 +22,7 @@
 #
 """Models for nuclear imaging."""
 
+from abc import ABC, ABCMeta, abstractmethod
 from os import cpu_count
 from typing import Union
 
@@ -35,113 +36,81 @@ from scipy.sparse.linalg import cg
 from nifreeze.data.pet import PET
 from nifreeze.model.base import BaseModel
 
-TIMEPOINT_XLIM_DATA_MISSING_ERROR_MSG = """\
-'timepoints' and 'xlim' must be specified, found: {timepoints} and {xlim}."""
-"""PET model underspecification error."""
+PET_OBJECT_ERROR_MSG = "Dataset MUST be a PET object."
+"""PET object error message."""
 
-FIRST_TIMEPOINT_VALUE_ERROR_MSG = """\
-First frame 'timepoint' should not be zero or negative, found: {timepoints}."""
-"""PET model timepoint value error message."""
-
-LAST_TIMEPOINT_CONSISTENCY_ERROR_MSG = """\
-Last frame 'timepoints' value should not be equal or greater than 'xlim' \
-duration, found: {timepoints} and {xlim}."""
-"""PET model parameter consistency error message."""
+PET_MIDFRAME_ERROR_MSG = "Dataset MUST have a 'midframe'."
+"""PET midframe error message."""
 
 DEFAULT_TIMEPOINT_TOL = 1e-2
 """Time frame tolerance in seconds."""
 
 
-class PETModel(BaseModel):
-    """A PET imaging realignment model based on B-Spline approximation."""
+def _exec_fit(model, data, chunk=None, **kwargs):
+    return model.fit(data, **kwargs), chunk
 
-    __slots__ = (
-        "_t",
-        "_x",
-        "_xlim",
-        "_order",
-        "_n_ctrl",
-        "_datashape",
-        "_mask",
-        "_smooth_fwhm",
-        "_thresh_pct",
-    )
+
+def _exec_predict(model, chunk=None, **kwargs):
+    """Propagate model parameters and call predict."""
+    return np.squeeze(model.predict(**kwargs)), chunk
+
+
+class BasePETModel(BaseModel, ABC):
+    """Interface and default methods for PET models."""
+
+    __metaclass__ = ABCMeta
+
+    __slots__ = {
+        "_data_mask": "A mask for the voxels that will be fitted and predicted",
+        "_smooth_fwhm": "FWHM in mm over which to smooth",
+        "_thresh_pct": "Thresholding percentile for the signal",
+        "_model_class": "Defining a model class",
+        "_modelargs": "Arguments acceptable by the underlying model",
+        "_models": "List with one or more (if parallel execution) model instances",
+    }
 
     def __init__(
         self,
         dataset: PET,
-        timepoints: list | np.ndarray,
-        xlim: float,
-        n_ctrl: int | None = None,
-        order: int = 3,
         smooth_fwhm: float = 10.0,
         thresh_pct: float = 20.0,
         **kwargs,
     ):
+        """Initialization.
+
+        Parameters
+        ----------
+        smooth_fwhm : obj:`float`
+            FWHM in mm over which to smooth the signal.
+        thresh_pct : obj:`float`
+            Thresholding percentile for the signal.
         """
-        Create the B-Spline interpolating matrix.
 
-        Parameters:
-        -----------
-        timepoints : :obj:`list`
-            The timing (in sec) of each PET volume.
-            E.g., ``[15.,   45.,   75.,  105.,  135.,  165.,  210.,  270.,  330.,
-            420.,  540.,  750., 1050., 1350., 1650., 1950., 2250., 2550.]``
-
-        n_ctrl : :obj:`int`
-            Number of B-Spline control points. If `None`, then one control point every
-            six timepoints will be used. The less control points, the smoother is the
-            model.
-
-        """
         super().__init__(dataset, **kwargs)
 
-        if timepoints is None or xlim is None:
-            raise ValueError(
-                TIMEPOINT_XLIM_DATA_MISSING_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
-            )
+        # Duck typing, instead of explicitly testing for PET type
+        if not hasattr(dataset, "total_duration"):
+            raise TypeError(PET_OBJECT_ERROR_MSG)
 
-        if timepoints[0] < DEFAULT_TIMEPOINT_TOL:
-            raise ValueError(FIRST_TIMEPOINT_VALUE_ERROR_MSG.format(timepoints=timepoints[0]))
+        if not hasattr(dataset, "midframe"):
+            raise ValueError(PET_MIDFRAME_ERROR_MSG)
 
-        if timepoints[-1] > xlim - DEFAULT_TIMEPOINT_TOL:
-            raise ValueError(
-                LAST_TIMEPOINT_CONSISTENCY_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
-            )
+        self._data_mask = (
+            dataset.brainmask
+            if dataset.brainmask is not None
+            else np.ones(dataset.dataobj.shape[:3], dtype=bool)
+        )
 
-        self._order = order
-        self._x = np.array(timepoints, dtype="float32")
-        self._xlim = xlim
         self._smooth_fwhm = smooth_fwhm
         self._thresh_pct = thresh_pct
 
-        # Calculate index coordinates in the B-Spline grid
-        self._n_ctrl = n_ctrl or (len(timepoints) // 4) + 1
-
-        # B-Spline knots
-        self._t = np.arange(-3, float(self._n_ctrl) + 4, dtype="float32")
-
-        self._datashape = None
-        self._mask = None
-
-    @property
-    def is_fitted(self) -> bool:
-        return self._locked_fit is not None
-
-    def _fit(self, index: int | None = None, n_jobs=None, **kwargs) -> int:
-        """Fit the model."""
-
-        if self._locked_fit is not None:
-            return n_jobs
-
-        if index is not None:
-            raise NotImplementedError("Fitting with held-out data is not supported")
-        timepoints = kwargs.get("timepoints", None) or self._x
-        x = np.asarray((np.array(timepoints, dtype="float32") / self._xlim) * self._n_ctrl)
-
+    def _preprocess_data(self) -> np.ndarray:
+        # ToDo
+        # data, _, gtab = self._dataset[idxmask]  ### This needs the PET data model to be changed
         data = self._dataset.dataobj
         brainmask = self._dataset.brainmask
 
+        # Preprocess the data
         if self._smooth_fwhm > 0:
             smoothed_img = smooth_image(
                 nb.Nifti1Image(data, self._dataset.affine), self._smooth_fwhm
@@ -153,7 +122,74 @@ class PETModel(BaseModel):
             data[data < thresh_val] = 0
 
         # Convert data into V (voxels) x T (timepoints)
-        data = data.reshape((-1, data.shape[-1])) if brainmask is None else data[brainmask]
+        return data.reshape((-1, data.shape[-1])) if brainmask is None else data[brainmask]
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._locked_fit is not None
+
+    @abstractmethod
+    def fit_predict(self, index: int | None = None, **kwargs) -> Union[np.ndarray, None]:
+        """Predict the corrected volume."""
+        return None
+
+
+class BSplinePETModel(BasePETModel):
+    """A PET imaging realignment model based on B-Spline approximation."""
+
+    __slots__ = (
+        "_t",
+        "_order",
+        "_n_ctrl",
+    )
+
+    def __init__(
+        self,
+        dataset: PET,
+        n_ctrl: int | None = None,
+        order: int = 3,
+        **kwargs,
+    ):
+        """Create the B-Spline interpolating matrix.
+
+        Parameters
+        ----------
+        n_ctrl : :obj:`int`
+            Number of B-Spline control points. If `None`, then one control point every
+            six timepoints will be used. The less control points, the smoother is the
+            model.
+        order : :obj:`int`
+            Order of the B-Spline approximation.
+        """
+
+        super().__init__(dataset, **kwargs)
+
+        self._order = order
+
+        # Calculate index coordinates in the B-Spline grid
+        self._n_ctrl = n_ctrl or (len(self._dataset.midframe) // 4) + 1
+
+        # B-Spline knots
+        self._t = np.arange(-3, self._n_ctrl + 4, dtype="float32")
+
+    def _fit(self, index: int | None = None, n_jobs=None, **kwargs) -> int:
+        """Fit the model."""
+
+        n_jobs = n_jobs or min(cpu_count() or 1, 8)
+
+        if self._locked_fit is not None:
+            return n_jobs
+
+        if index is not None:
+            raise NotImplementedError("Fitting with held-out data is not supported")
+
+        data = self._preprocess_data()
+
+        x = (
+            np.asarray(self._dataset.midframe, dtype="float32")
+            / self._dataset.total_duration
+            * self._n_ctrl
+        )
 
         # A.shape = (T, K - 4); T= n. timepoints, K= n. knots (with padding)
         A = BSpline.design_matrix(x, self._t, k=self._order)
@@ -161,15 +197,21 @@ class PETModel(BaseModel):
         ATdotA = AT @ A
 
         # Parallelize process with joblib
-        with Parallel(n_jobs=n_jobs or min(cpu_count() or 1, 8)) as executor:
+        with Parallel(n_jobs=n_jobs) as executor:
             results = executor(delayed(cg)(ATdotA, AT @ v) for v in data)
 
-        self._locked_fit = np.array([r[0] for r in results])
+        self._locked_fit = np.asarray([r[0] for r in results])
 
         return n_jobs
 
     def fit_predict(self, index: int | None = None, **kwargs) -> Union[np.ndarray, None]:
         """Return the corrected volume using B-spline interpolation."""
+
+        # ToDo
+        # Does the below apply to PET ? Martin has the return None statement
+        # if index is None:
+        #    raise RuntimeError(
+        #        f"Model {self.__class__.__name__} does not allow locking.")
 
         # Fit the BSpline basis on all data
         if self._locked_fit is None:
@@ -183,7 +225,10 @@ class PETModel(BaseModel):
             return None
 
         # Project sample timing into B-Spline coordinates
-        x = np.asarray((index / self._xlim) * self._n_ctrl)
+        # ToDo: x is not really a matrix ...
+        x = np.asarray(
+            (self._dataset.midframe[index] / self._dataset.total_duration) * self._n_ctrl
+        )
         A = BSpline.design_matrix(x, self._t, k=self._order)
 
         # A is 1 (num. timepoints) x C (num. coeff)

--- a/test/test_integration_pet.py
+++ b/test/test_integration_pet.py
@@ -102,7 +102,7 @@ def test_pet_motion_estimator_run(monkeypatch, setup_random_pet_data):
     )
 
     class DummyModel:
-        def __init__(self, dataset, timepoints, xlim):
+        def __init__(self, dataset):
             self.dataset = dataset
 
         def fit_predict(self, index):
@@ -110,7 +110,7 @@ def test_pet_motion_estimator_run(monkeypatch, setup_random_pet_data):
                 return None
             return np.zeros(self.dataset.shape3d, dtype=np.float32)
 
-    monkeypatch.setattr("nifreeze.estimator.PETModel", DummyModel)
+    monkeypatch.setattr("nifreeze.estimator.BSplinePETModel", DummyModel)
 
     class DummyRegistration:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Refactor PET model: use a base class that contains the essential properties for a PET model and create a derived class that implements the B-Spline correction.

In the base class:
- Remove the `timepoints` attribute: it corresponds to the PET dataset `midframe` attribute, and thus, there is no need to duplicate it in the model.
- Remove the `xlim` attribute: it corresponds to the PET dataset `total_duration` attribute, and thus, there is no need to duplicate it in the model.
- Remove the checks related to the above attributes: checking the coherence of their values is not the model's responsibility, and should be done when instantiating the dataset.

Make the model use the frame index instead of the `midframe` value as the argument of the `fit_predict` function. This increases makes the PET model be consistent with the approach used in the code base as a principle for generalization in the framework.

The index was also marked as an integer by the type annotations (as it should be expected), whereas `midframe` values that were being provided are typically floating point values.

Change the tests and the PET notebook accordingly.

In the derived, BSpline class:
- Remove the unnecessary explicit `float` casting around the number of control points: the `dtype="float32"` specifier creates a float array.
  Fixes:
  ```
  Expected type 'str | Buffer | SupportsFloat | SupportsIndex', got 'Literal[0] | None | {__eq__} | int' instead
  ```
  raised by the IDE.

Take advantage of the commit to use `np.asarray` to avoid extra copies when not necessary.

Cast explicitly to `int` when getting the frame indices in the estimator's `run` method to avoid type checking errors:
```
src/nifreeze/estimator.py:274: error:
 Argument 1 to "fit_predict" of "BSplinePETModel" has incompatible type
 "signedinteger[_32Bit | _64Bit]"; expected "int | None"  [arg-type]
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/20402438629/job/58626813972#step:8:35