### PR TITLE
DOC: Miscellaneous documentation fixes

### DIFF
--- a/src/nifreeze/viz/motion_viz.py
+++ b/src/nifreeze/viz/motion_viz.py
@@ -84,7 +84,7 @@ def plot_framewise_displacement(
         Framewise displacement values corresponding.
     labels : :obj:`list`
         Labels for legend.
-    cmap_name : str, optional
+    cmap_name : :obj:`str`, optional
         Colormap name.
     ax : :obj:`Axes`, optional
         Figure axes.

--- a/src/nifreeze/viz/motion_viz.py
+++ b/src/nifreeze/viz/motion_viz.py
@@ -81,7 +81,7 @@ def plot_framewise_displacement(
     Parameters
     ----------
     fd : :obj:`~pd.DataFrame`
-        Framewise displacement values corresponding.
+        Framewise displacement values.
     labels : :obj:`list`
         Labels for legend.
     cmap_name : :obj:`str`, optional


### PR DESCRIPTION
- DOC: Use `:obj:` before `str` so that the type is linked
- DOC: Remove orphan sentence ending word