### PR TITLE
FIX: Use motion corrected frame index consistently in PET notebook

### DIFF
--- a/docs/notebooks/pet_motion_estimation.ipynb
+++ b/docs/notebooks/pet_motion_estimation.ipynb
@@ -428,7 +428,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predicted = model.fit_predict(pet_dataset.midframe[2])"
+    "index = 2\n",
+    "predicted = model.fit_predict(pet_dataset.midframe[index])"
    ]
   },
   {
@@ -441,12 +442,12 @@
     "import nibabel as nb\n",
     "\n",
     "# before\n",
-    "nifti_img_before = nb.Nifti1Image(predicted, pet_dataset.affine)\n",
+    "nifti_img_before = nb.Nifti1Image(pet_dataset[index][0], pet_dataset.affine)\n",
     "output_path_before = \"before_mc.nii\"\n",
     "nifti_img_before.to_filename(output_path_before)\n",
     "\n",
     "# after\n",
-    "nifti_img_after = nb.Nifti1Image(data_test[0], pet_dataset.affine)\n",
+    "nifti_img_after = nb.Nifti1Image(predicted, pet_dataset.affine)\n",
     "output_path_after = \"after_mc.nii\"\n",
     "nifti_img_after.to_filename(output_path_after)"
    ]
@@ -2236,7 +2237,7 @@
     "    fixed_image,\n",
     "    moving_image,\n",
     "    fixed_label=\"PET_before\",\n",
-    "    moving_label=\"PET\",\n",
+    "    moving_label=\"PET_after\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
Use motion corrected frame index consistently in PET notebook: define the index and use it instead of relying in the train, test splits done though the `lofo_split` call, which is also using a different index.