### PR TITLE
REF: Inherit base model class from `ABC` to enforce native abstraction

### DIFF
--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -22,7 +22,7 @@
 #
 """Base infrastructure for nifreeze's models."""
 
-from abc import abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from typing import Union
 from warnings import warn
 
@@ -77,7 +77,7 @@ class ModelFactory:
         raise NotImplementedError(f"Unsupported model <{model}>.")
 
 
-class BaseModel:
+class BaseModel(ABC):
     """
     Defines the interface and default methods.
 
@@ -87,6 +87,8 @@ class BaseModel:
     and to read (see https://www.youtube.com/watch?v=3MNVP9-hglc).
 
     """
+
+    __metaclass__ = ABCMeta
 
     __slots__ = ("_dataset", "_locked_fit")
 
@@ -116,7 +118,7 @@ class BaseModel:
             If ``None``, no prediction will be executed.
 
         """
-        raise NotImplementedError("Cannot call fit_predict() on a BaseModel instance.")
+        return None
 
 
 class TrivialModel(BaseModel):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -35,6 +35,16 @@ from nifreeze.model.base import mask_absence_warn_msg
 from nifreeze.testing import simulations as _sim
 
 
+def test_base_model():
+    from nifreeze.model.base import BaseModel
+
+    with pytest.raises(
+        TypeError,
+        match="Can't instantiate abstract class BaseModel without an implementation for abstract method 'fit_predict'",
+    ):
+        BaseModel(None)
+
+
 @pytest.mark.parametrize("use_mask", (False, True))
 def test_trivial_model(request, use_mask):
     """Check the implementation of the trivial B0 model."""


### PR DESCRIPTION
Inherit base model class from `ABC` to enforce native abstraction.

Fixes:
```
Abstract methods are allowed in classes whose metaclass is 'ABCMeta'
```

raised locally by the IDE.