### PR TITLE
DOC: Miscellaneous documentation fixes

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ External Dependencies
 ---------------------
 *nifreeze* requires ANTs_, which is leveraged through the Nipype_ Python
 interface for registration purposes. There are
-[several ways to install ``ANTs``](https://github.com/ANTsX/ANTs?tab=readme-ov-file#installation).
+`several ways to install ANTs <https://github.com/ANTsX/ANTs?tab=readme-ov-file#installation>`__.
 Notably, the path to the installed binaries needs to be added to the ``PATH`` ::
 
    $ export PATH=/path/to/ants/bin:$PATH

--- a/src/nifreeze/analysis/filtering.py
+++ b/src/nifreeze/analysis/filtering.py
@@ -34,9 +34,9 @@ def normalize(x: np.ndarray):
 
         z_i = \frac{x_i - \mu}{\sigma}
 
-    where $x_i$ is the framewise displacement at point $i$, $\mu$ is the mean
-    of all values, $\sigma$ is the standard deviation of the values, and $z_i$
-    is the normalized z-score.
+    where :math:`x_i` is the framewise displacement at point :math:`i`,
+    :math:`\mu` is the mean of all values, :math:`\sigma` is the standard
+    deviation of the values, and :math:`z_i` is the normalized z-score.
 
     Parameters
     ----------

--- a/src/nifreeze/model/gqi.py
+++ b/src/nifreeze/model/gqi.py
@@ -206,8 +206,8 @@ def prediction_kernel(gtab, param_lambda, sphere, method="standard"):
 
         S(\theta, b) = K_{ii}^{-1} \cdot ODF
 
-    where $K_{ii}^{-1}$, is the inverse of the GQI kernels for the direction(s) $ii$
-    given by ``gtab``.
+    where :math:`K_{ii}^{-1}`, is the inverse of the GQI kernels for the
+    direction(s) :math:`ii` given by ``gtab``.
 
     """
     # K.shape = (n_gradients, n_vertices)

--- a/src/nifreeze/testing/simulations.py
+++ b/src/nifreeze/testing/simulations.py
@@ -227,8 +227,8 @@ def create_random_polar_angles(size, rng):
 
 
 def create_random_diffusivity_eigenvalues(size, rng):
-    r"""Create DTI model diffusion tensor eigenvalues ($\lambda_{1},
-    \lambda_{2}, \lambda_{3}$) drawn from a uniform distribution."""
+    r"""Create DTI model diffusion tensor eigenvalues (:math:`\lambda_{1}, \lambda_{2}, \lambda_{3}`)
+    drawn from a uniform distribution."""
 
     # lambda_2 = lambda_3 following Canales-Rodriguez, NIMG 184 2019,
     # https://doi.org/10.1016/j.neuroimage.2018.08.071

--- a/src/nifreeze/viz/motion_viz.py
+++ b/src/nifreeze/viz/motion_viz.py
@@ -129,7 +129,7 @@ def plot_volumewise_motion(
 ) -> np.ndarray:
     """Plot mean volume-wise motion parameters.
 
-    Plots the mean translation and rotation parameters along the ``x``, `y``,
+    Plots the mean translation and rotation parameters along the ``x``, ``y``,
     and ``z`` axes.
 
     Parameters


### PR DESCRIPTION
- DOC: Fix hyperlink in installation instructions
- DOC: Fix inline math syntax in docstrings
- DOC: Add missing backtick for inline literal in docstring 