### PR TITLE
DOC: Remove `napoleon` custom section mapping from configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,16 +65,7 @@ autodoc_mock_imports = [
     "transforms3d",
 ]
 
-# Accept custom section names to be parsed for numpy-style docstrings
-# of parameters.
 napoleon_use_param = False
-napoleon_custom_sections = [
-    ("Inputs", "Parameters"),
-    ("Outputs", "Parameters"),
-    ("Attributes", "Parameters"),
-    ("Mandatory Inputs", "Parameters"),
-    ("Optional Inputs", "Parameters"),
-]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
Remove `napoleon` custom section mapping from documentation configuration: as opposed to e.g. `dmriprep`, `fmriprep`, etc. `nifreeze` does not deal with workflows. Thus, no special `Inputs`, `Outputs`, etc. sections need to be mapped. For now, there is no `Attributes` sections either.