### PR TITLE
DOC: Remove legacy eddymotion DOI from README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,6 @@ and eddy-current-derived distortion estimation in dMRI.
    The contributor list of *eddymotion* is found under the credit file
    ``.maint/EDDYMOTION.md`` in this repository.
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4680599.svg
-   :target: https://doi.org/10.5281/zenodo.4680599
-   :alt: DOI
-
 .. image:: https://img.shields.io/badge/License-Apache_2.0-blue.svg
    :target: https://github.com/nipreps/nifreeze/blob/main/LICENSE
    :alt: License


### PR DESCRIPTION
Remove legacy eddymotion DOI from README file: the package has been revamped significantly since the work referenced by that DOI, has been renamed to `nifreeze` and can be cited through the reference contained in the `CITATION.cff` file.