### PR TITLE
FIX: Fix variable name for plot in PET notebook

### DIFF
--- a/docs/notebooks/pet_motion_estimation.ipynb
+++ b/docs/notebooks/pet_motion_estimation.ipynb
@@ -2487,7 +2487,7 @@
     "\n",
     "from nifreeze.viz.motion_viz import plot_volumewise_motion\n",
     "\n",
-    "plot_volumewise_motion(np.arange(len(fd)), motion_parameters)\n",
+    "plot_volumewise_motion(np.arange(len(estimated_fd)), motion_parameters)\n",
     "\n",
     "plt.show()"
    ]


### PR DESCRIPTION
Fix variable for plot in PET notebook: missed to use the appropriate variable name in commit 0357331.