### PR TITLE
DOC: Link exceptions to Python documentation

### DIFF
--- a/src/nifreeze/data/__init__.py
+++ b/src/nifreeze/data/__init__.py
@@ -55,7 +55,7 @@ def load(
 
     Raises
     ------
-    ValueError
+    :exc:`ValueError`
         If the file extension is not supported or the file cannot be loaded.
 
     """

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -334,7 +334,7 @@ def from_nii(
 
     Raises
     ------
-    RuntimeError
+    :exc:`RuntimeError`
         If no gradient information is provided (neither ``gradients_file`` nor
         ``bvec_file`` + ``bval_file``).
 

--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -257,7 +257,7 @@ def from_nii(
 
     Raises
     ------
-    RuntimeError
+    :exc:`RuntimeError`
         If ``frame_time`` is not provided (BIDS requires it).
 
     """


### PR DESCRIPTION
Link exceptions to Python documentation by using the `:exc:` role.