### PR TITLE
TST: Use a local random generator in spike identification test

### DIFF
--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -144,15 +144,15 @@ def test_identify_bland_altman_salient_data():
     assert len(salient_data[BASalientEntity.RIGHT_MASK.value]) == len(_data1)
 
 
-def test_identify_spikes(request):
-    rng = request.node.rng
+def test_identify_spikes():
+    rng = np.random.default_rng(1234)
 
     n_samples = 450
 
     fd = rng.normal(0, 5, n_samples)
     threshold = 2.0
 
-    expected_indices = np.asarray([42, 48, 61, 80, 98, 103, 113, 143, 324, 387, 422, 436, 449])
+    expected_indices = np.asarray([5, 57, 85, 100, 127, 180, 191, 202, 335, 393, 409])
     expected_mask = np.zeros(n_samples, dtype=bool)
     expected_mask[expected_indices] = True
 


### PR DESCRIPTION
Use a local random generator in spike identification test: when using the `random_number_generator` fixture, every time `conftest.py` is modified (even if the seed to the named fixture remains unchanged), the spike indices change, and thus the test fails since the expected indices are hard-coded. Using a local random generator avoids this issue.

The rest of the tests using random data do not rely on particular values being generated, and thus changes to `conftest.py` do not have an effect on them.

Related to
https://github.com/nipreps/nifreeze/pull/181#issuecomment-3111742251 https://github.com/nipreps/nifreeze/pull/160#issuecomment-2954147226