### PR TITLE
REF: Allow bvals and bvecs to be separate fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,8 @@ addopts = "-v --doctest-modules"
 doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
 env = "PYTHONHASHSEED=0"
 markers = [
+  "random_bval_data: Custom marker for random b-val data tests",
+  "random_bvec_data: Custom marker for random b-vec data tests",
   "random_gtab_data: Custom marker for random gtab data tests",
   "random_dwi_data: Custom marker for random dwi data tests",
   "random_pet_data: Custom marker for random pet data tests",

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -93,16 +93,23 @@ def test_advanced_clip(
     )
 
 
-@pytest.mark.random_gtab_data(5, (1000, 2000, 3000), 1)
 @pytest.mark.parametrize(
-    "index, expect_exception, expected_output",
+    "bvals, index, expect_exception, expected_output, bval_tolerance",
     [
-        (3, False, np.asarray([False, True, True, False, False, False])),
-        (0, True, np.asarray([])),
+        (
+            np.asarray([0, 1000, 1000, 1000, 2000, 3000]),
+            3,
+            False,
+            np.asarray([False, True, True, False, False, False]),
+            50,
+        ),
+        (np.asarray([0, 1000, 1000, 1000, 2000, 3000]), 0, True, np.asarray([]), 50),
     ],
 )
-def test_dwi_select_shells(setup_random_gtab_data, index, expect_exception, expected_output):
-    bvals, bvecs = setup_random_gtab_data
+def test_dwi_select_shells(
+    setup_random_bvec_data, bvals, index, expect_exception, expected_output, bval_tolerance
+):
+    bvecs = setup_random_bvec_data
 
     gradients = np.vstack([bvecs, bvals[np.newaxis, :]], dtype="float32")
 


### PR DESCRIPTION
Allow bvals and bvecs to be separate fixtures. The DWI shell selection test was failing in
https://github.com/nipreps/nifreeze/actions/runs/18065201218/job/51406989162#step:11:2848 with
```
          if not shellmask.sum():
  >           raise RuntimeError(f"Shell corresponding to index {index} (b={bcenter}) is empty.")
  E           RuntimeError: Shell corresponding to index 3 (b=2000.0) is empty.
```

When changing `conftest.py` for other purposes, the above test, which was affected since the `bvals` generated by the
`setupt_random_gtab_data` fixture did not match the previous version, and the test's hard-coded expected values no longer matched the existing ones.

Solve the issue by adding two separate fixtures for bvals an bvecs. For the above test bvals will have some fixed values (i.e. will not used the fixture), and the bvecs fixture will provide some random values depending on the bvals (i.e. the number of created directions depending on the number of b0s and number of non-zero b-values).

Do not use make the bvec fixture be invoked automatically for all tests (i.e. do not use `autouse=True`) to avoid the
```
fixture 'bvals' not found
```

error. This way, only tests that explicitly request the bvec fixture (`setup_random_bvec_data`) and are properly parametrized with `bvals` will use it.

Refactor the gtab fixture to call the private functions that create random bval and bvec values.

The issue is related to commit e353bbd.