### PR TITLE
FIX: Pass `**kwargs` to `TrivialModel` instantiation in factory

### DIFF
--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -61,7 +61,7 @@ class ModelFactory:
             raise RuntimeError("No model identifier provided.")
 
         if model.lower() == "trivial":
-            return TrivialModel(kwargs.pop("dataset"))
+            return TrivialModel(kwargs.pop("dataset"), **kwargs)
 
         if model.lower() in ("avg", "average", "mean"):
             return ExpectationModel(kwargs.pop("dataset"), **kwargs)


### PR DESCRIPTION
Pass `kwargs` to `TrivialModel` instantiation in factory: unless `**kwargs` are passed, the instance will never receive the `predicted` parameter.

Test the trivial model instantiation through the model factory.