### PR TITLE
FIX: Doctests for ``compute_pairwise_angles`` (Python 3.12, Numpy 2+)

### DIFF
--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -587,12 +587,18 @@ def compute_pairwise_angles(
     Examples
     --------
     >>> X = np.asarray([(1.0, -1.0), (0.0, 0.0), (0.0, 0.0)]).T
-    >>> compute_pairwise_angles(X, closest_polarity=False)[0, 1]  # doctest: +ELLIPSIS
-    3.1415...
+    >>> np.isclose(
+    ...     compute_pairwise_angles(X, closest_polarity=False)[0, 1],
+    ...     np.pi,
+    ... )
+    True
     >>> X = np.asarray([(1.0, -1.0), (0.0, 0.0), (0.0, 0.0)]).T
     >>> Y = np.asarray([(1.0, -1.0), (0.0, 0.0), (0.0, 0.0)]).T
-    >>> compute_pairwise_angles(X, Y, closest_polarity=False)[0, 1]  # doctest: +ELLIPSIS
-    3.1415...
+    >>> np.isclose(
+    ...     compute_pairwise_angles(X, Y, closest_polarity=False)[0, 1],
+    ...     np.pi,
+    ... )
+    True
     >>> X = np.asarray([(1.0, -1.0), (0.0, 0.0), (0.0, 0.0)]).T
     >>> compute_pairwise_angles(X)[0, 1]
     0.0


### PR DESCRIPTION
## Summary
- update the compute_pairwise_angles doctest examples to use numpy.isclose for comparisons

## Testing
- python -m pytest --doctest-modules src/nifreeze/model/gpr.py

------
https://chatgpt.com/codex/tasks/task_e_68e4e27435e48330ad77a02b8dee0b4b