### PR TITLE
FIX: Ensure benchmark workflow uses absolute ASV config path

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,5 +55,6 @@ jobs:
         export OMP_NUM_THREADS=1
     - name: Run benchmarks
       run: |
-        asv machine --yes --config benchmarks/asv.conf.json
-        asv run --config benchmarks/asv.conf.json --show-stderr
+        CONFIG_FILE="$(pwd)/benchmarks/asv.conf.json"
+        asv machine --yes --config "$CONFIG_FILE"
+        asv run --config "$CONFIG_FILE" --show-stderr


### PR DESCRIPTION
## Summary
- ensure the benchmark workflow resolves the ASV configuration file to an absolute path so it remains valid when ASV changes directories

## Testing
- not run (not run on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68e4e565a59883308dd4ac897bb923cf