### PR TITLE
STY: Add the `mypy` flag to check untyped function bodies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,9 @@ version-file = "src/nifreeze/_version.py"
 # Developer tool configurations
 #
 
+[tool.mypy]
+check_untyped_defs = true
+
 [[tool.mypy.overrides]]
 module = [
   "nipype.*",


### PR DESCRIPTION
Add the `mypy` flag to check untyped function bodies.

Fixes:
```
test/test_parser.py:292: note:
 By default the bodies of untyped functions are not checked,
 consider using --check-untyped-defs  [annotation-unchecked]
test/test_parser.py:294: note:
 By default the bodies of untyped functions are not checked,
 consider using --check-untyped-defs  [annotation-unchecked]
test/test_main.py:92: note:
 By default the bodies of untyped functions are not checked,
 consider using --check-untyped-defs  [annotation-unchecked]
test/test_main.py:94: note:
 By default the bodies of untyped functions are not checked,
 consider using --check-untyped-defs  [annotation-unchecked]
test/test_main.py:99: note:
 By default the bodies of untyped functions are not checked,
 consider using --check-untyped-defs  [annotation-unchecked]
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18418756623/job/52488477896?pr=271#step:8:34