### PR TITLE
STY: Fix `mypy` override paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,9 +233,7 @@ branch = true
 parallel = true
 concurrency = ["multiprocessing"]
 omit = [
-  "*/tests/*",
-  "*/testing/*",
-  "*/viz/*",
+  "^test/*",
   "*/__init__.py",
   "*/conftest.py",
   "src/nifreeze/_version.py"


### PR DESCRIPTION
Fix `mypy` override paths:
- Use `test` to exclude files in the testing folder instead of the non-existing `tests` or `testing`.
- Remove `viz` from the listed paths so that the functions in the files contained in that folder get their types checked.