### PR TITLE
STY: Fix `nibabel` image loading type errors

### DIFF
--- a/benchmarks/benchmarks/bench_model.py
+++ b/benchmarks/benchmarks/bench_model.py
@@ -34,6 +34,7 @@ from scipy.ndimage import binary_dilation
 from skimage.morphology import ball
 
 from nifreeze.model.gpr import DiffusionGPR, SphericalKriging
+from nifreeze.utils.ndimage import load_api
 
 
 class DiffusionGPRBenchmark(ABC):
@@ -67,7 +68,7 @@ class DiffusionGPRBenchmark(ABC):
         name = "sherbrooke_3shell"
 
         dwi_fname, bval_fname, bvec_fname = dpd.get_fnames(name=name)
-        dwi_data = nb.load(dwi_fname).get_fdata()
+        dwi_data = load_api(dwi_fname, nb.Nifti1Image).get_fdata()
         bvals, bvecs = read_bvals_bvecs(bval_fname, bvec_fname)
 
         _, brain_mask = median_otsu(dwi_data, vol_idx=[0])

--- a/test/test_data_dmri.py
+++ b/test/test_data_dmri.py
@@ -30,6 +30,7 @@ import pytest
 
 from nifreeze.data import load
 from nifreeze.data.dmri import DWI, find_shelling_scheme, from_nii, transform_fsl_bvec
+from nifreeze.utils.ndimage import load_api
 
 
 def _dwi_data_to_nifti(
@@ -90,7 +91,7 @@ def test_load(datadir, tmp_path, insert_b0, rotate_bvecs):  # noqa: C901
 
     dwi_h5.to_nifti(dwi_nifti_path, insert_b0=insert_b0)
 
-    nifti_data = nb.load(dwi_nifti_path).get_fdata()
+    nifti_data = load_api(dwi_nifti_path, nb.Nifti1Image).get_fdata()
     if insert_b0:
         nifti_data = nifti_data[..., 1:]
 

--- a/test/test_data_pet.py
+++ b/test/test_data_pet.py
@@ -30,6 +30,7 @@ import pytest
 from nitransforms.linear import Affine
 
 from nifreeze.data.pet import PET, _compute_frame_duration, _compute_uptake_statistic, from_nii
+from nifreeze.utils.ndimage import load_api
 
 
 @pytest.fixture
@@ -108,7 +109,7 @@ def test_from_nii_requires_frame_time(setup_random_uniform_spatial_data, tmp_pat
 )
 def test_from_nii(tmp_path, random_nifti_file, brainmask_file, frame_time, frame_duration):
     filename = random_nifti_file
-    img = nb.load(filename)
+    img = load_api(filename, nb.Nifti1Image)
     if brainmask_file:
         mask_data = np.ones(img.get_fdata().shape[:-1], dtype=bool)
         mask_img = nb.Nifti1Image(mask_data.astype(np.uint8), img.affine)
@@ -148,7 +149,7 @@ def test_to_nifti(tmp_path, random_dataset):
     out_filename = tmp_path / "random_pet_out.nii.gz"
     random_dataset.to_nifti(str(out_filename))
     assert out_filename.exists()
-    loaded_img = nb.load(str(out_filename))
+    loaded_img = load_api(str(out_filename), nb.Nifti1Image)
     assert np.allclose(loaded_img.get_fdata(), random_dataset.dataobj)
     assert np.allclose(loaded_img.affine, random_dataset.affine)
     units = loaded_img.header.get_xyzt_units()
@@ -163,12 +164,12 @@ def test_to_nifti(tmp_path, random_dataset):
 )
 def test_round_trip(tmp_path, random_nifti_file, frame_time, frame_duration):
     filename = random_nifti_file
-    img = nb.load(filename)
+    img = load_api(filename, nb.Nifti1Image)
     pet_obj = from_nii(filename, frame_time=frame_time, frame_duration=frame_duration)
     out_fname = tmp_path / "random_pet_out.nii.gz"
     pet_obj.to_nifti(out_fname)
     assert out_fname.exists()
-    loaded_img = nb.load(out_fname)
+    loaded_img = load_api(out_fname, nb.Nifti1Image)
     np.testing.assert_array_equal(loaded_img.affine, img.affine)
     np.testing.assert_allclose(loaded_img.get_fdata(), img.get_fdata())
     units = loaded_img.header.get_xyzt_units()

--- a/test/test_data_utils.py
+++ b/test/test_data_utils.py
@@ -26,6 +26,7 @@ import numpy as np
 import numpy.testing as npt
 
 from nifreeze.data.utils import apply_affines
+from nifreeze.utils.ndimage import load_api
 
 
 def test_apply_affines(request, tmp_path):
@@ -52,6 +53,6 @@ def test_apply_affines(request, tmp_path):
     npt.assert_array_equal(nii.affine, nii_t_file.affine)
     assert out_fname.exists()
     # The saved file should load and match the expected result
-    nii_loaded = nb.load(out_fname)
+    nii_loaded = load_api(out_fname, nb.Nifti1Image)
     npt.assert_allclose(nii.dataobj, nii_loaded.dataobj)
     npt.assert_array_equal(nii.affine, nii_loaded.affine)


### PR DESCRIPTION
Fix `nibabel` image loading type errors: use the internal `load_api` function to coerce type checking to consider the loaded image as a `Nifti1Image` instead of a `FileBasedImage`, which is not guaranteed to have e.g. th `dataobj` or `affine` attributes.

Fixes:
```
test/test_data_utils.py:56: error: "FileBasedImage" has no attribute "dataobj"  [attr-defined]
```

and similar errors raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18419804385/job/52491575644?pr=273#step:8:34