### PR TITLE
STY: Fix PET classes type checking errors

### DIFF
--- a/src/nifreeze/model/pet.py
+++ b/src/nifreeze/model/pet.py
@@ -157,6 +157,10 @@ class PETModel(BaseModel):
         if self._locked_fit is None:
             self._fit(index, n_jobs=kwargs.pop("n_jobs", None), **kwargs)
 
+        # Make type checking happy by preventing it to signal that None has no
+        # attribute T: after this point, _locked_fit should no longer be None
+        assert self._locked_fit is not None, "Internal error: _locked_fit has not been set"
+
         if index is None:  # If no index, just fit the data.
             return None
 

--- a/test/test_model_pet.py
+++ b/test/test_model_pet.py
@@ -65,6 +65,7 @@ def test_petmodel_fit_predict(random_dataset):
 
     # Predict at a specific timepoint
     vol = model.fit_predict(random_dataset.midframe[2])
+    assert vol is not None
     assert vol.shape == random_dataset.shape3d
     assert vol.dtype == random_dataset.dataobj.dtype
 


### PR DESCRIPTION
Fix PET classes type checking errors:
- Ensure that `_locked_fit` is set before attempting to transpose it.
- Ensure that `vol` is not `None` in test before querying about its attributes.

Fixes:
```
src/nifreeze/model/pet.py:169: error:
 Item "None" of "Any | None" has no attribute "T"  [union-attr]
```

and
```
test/test_model_pet.py:68: error:
 Item "None" of "ndarray[Any, Any] | None" has no attribute "shape"  [union-attr]
test/test_model_pet.py:69: error:
 Item "None" of "ndarray[Any, Any] | None" has no attribute "dtype"  [union-attr]
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/18428489877/job/52512798218?pr=273#step:8:52