### PR TITLE
STY: Fix miscellaneous type errors

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -41,10 +41,11 @@ def test_proximity_estimator_trivial_model(motion_data, tmp_path):
 
     model = TrivialModel(dwi_motion)
     estimator = Estimator(model)
+    cpus = cpu_count()
     estimator.run(
         dwi_motion,
         seed=12345,
-        num_threads=min(cpu_count(), 8),
+        num_threads=min(cpus if cpus is not None else 1, 8),
     )
 
     # Uncomment to see the realigned dataset

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -54,7 +54,7 @@ def test_base_model():
         TypeError,
         match="Can't instantiate abstract class BaseModel without an implementation for abstract method 'fit_predict'",
     ):
-        BaseModel(None)
+        BaseModel(None)  # type: ignore[abstract]
 
 
 @pytest.mark.parametrize("use_mask", (False, True))
@@ -84,7 +84,7 @@ def test_trivial_model(request, use_mask):
     )
 
     data = DWI(
-        dataobj=(*_S0.shape, 10),
+        dataobj=rng.normal(size=(*_S0.shape, 10)),
         bzero=_clipped_S0,
         brainmask=mask,
     )
@@ -200,13 +200,13 @@ def test_dti_model(setup_random_dwi_data):
 
     dtimodel = model.DTIModel(dataset)
     predicted = dtimodel.fit_predict(4)
-
+    assert predicted is not None
     assert predicted.shape == dwi_dataobj.shape[:-1]
 
 
 def test_factory_none_raises(setup_random_base_data):
     dataobj, affine, brainmask, motion_affines, datahdr = setup_random_base_data
-    dataset = BaseDataset(
+    dataset: BaseDataset = BaseDataset(
         dataobj=dataobj,
         affine=affine,
         brainmask=brainmask,
@@ -235,7 +235,7 @@ def test_model_factory_invalid_model():
 )
 def test_factory_variants(name, expected_cls, setup_random_base_data):
     dataobj, affine, brainmask, motion_affines, datahdr = setup_random_base_data
-    dataset = BaseDataset(
+    dataset: BaseDataset = BaseDataset(
         dataobj=dataobj,
         affine=affine,
         brainmask=brainmask,
@@ -277,7 +277,7 @@ def test_factory_avgdwi_variants(monkeypatch, name, setup_random_dwi_data):
 
     old_module = sys.modules.get("nifreeze.model.dmri")
     dmri_module = _types.ModuleType("nifreeze.model.dmri")
-    dmri_module.AverageDWIModel = DummyAvgDWI
+    dmri_module.AverageDWIModel = DummyAvgDWI  # type: ignore[attr-defined]
     sys.modules["nifreeze.model.dmri"] = dmri_module
 
     try:


### PR DESCRIPTION
Fix miscellaneous type errors:
- Ignore testing the instantiation of the abstract `BaseModel` class and pass `None` to silence errors related to its `dataset` positional argument.
- Build a proper array for the `DWI` dataset class `dataobj` attribute: the previous implementation was passing a tuple with the dimensionality instead of an array of actual values.
- Ensure that the result of `fit_predict` is not `None` in test before querying about its attributes.
- Annotate base dataset class instances.
- Ignore monkeypatched/dynamically created class when assigning it to `nifreeze.model.dmri` module for type checking purposes, as `mypy`, being a static checking tool, raises errors for types added at runtime.
- Ensure that the argument to `min` is not `None` when deciding the number of CPUs: store the CPU count in a variable and use 1 if `None`.

Fixes:
```
test/test_model.py:57: error:
 Cannot instantiate abstract class "BaseModel" with abstract attribute "fit_predict"  [abstract]
```

and
```
test/test_model.py:87: error:
 Argument "dataobj" to "DWI" has incompatible type "tuple[Any, ...]"; expected "ndarray[Any, Any]"  [arg-type]
test/test_model.py:89: error:
 Argument "brainmask" to "DWI" has incompatible type "ndarray[Any, dtype[Any]] | None"; expected "ndarray[Any, Any]"  [arg-type]
```

and
```
test/test_model.py:204: error:
 Item "None" of "ndarray[Any, Any] | None" has no attribute "shape"  [union-attr]
```

and
```
test/test_model.py:209: error:
 Need type annotation for "dataset"  [var-annotated]
test/test_model.py:238: error:
 Need type annotation for "dataset"  [var-annotated]
```

and
```
test/test_model.py:280: error:
 Module has no attribute "AverageDWIModel"  [attr-defined]
```

and
```
test/test_integration.py:47: error:
 Value of type variable "SupportsRichComparisonT" of "min" cannot be "int | None"  [type-var]
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18429664690/job/52515354565?pr=273#step:8:53