### PR TITLE
STY: Fix miscellaneous type check errors (part 2)

### DIFF
--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -35,7 +35,7 @@ class DummyModel(BaseModel):
         self._rng = np.random.default_rng(1234)
         super().__init__(**kwargs)
 
-    def fit_predict(self, idx=None, **kwargs):
+    def fit_predict(self, index: int | None = None, **kwargs):
         # Return a synthetic 3D image
         return self._rng.random(DATAOBJ_SIZE[:-1])
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -60,6 +60,7 @@ def test_base_model():
 @pytest.mark.parametrize("use_mask", (False, True))
 def test_trivial_model(request, use_mask):
     """Check the implementation of the trivial B0 model."""
+    from typing import Any
 
     rng = request.node.rng
 
@@ -69,6 +70,7 @@ def test_trivial_model(request, use_mask):
 
     size = (2, 2, 2)
     mask = None
+    context: contextlib.AbstractContextManager[Any]
     if use_mask:
         mask = np.ones(size, dtype=bool)
         context = contextlib.nullcontext()

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -264,11 +264,12 @@ def test_parsed_dwimodel_instatiation(setup_random_dwi_data, datadir, models):
     )
 
     if models == "dti":
-        model = DTIModel(dataset, **model_kwargs)
-        assert model._model_class == "dipy.reconst.dti.TensorModel"
+        assert DTIModel(dataset, **model_kwargs)._model_class == "dipy.reconst.dti.TensorModel"
     elif models == "dki":
-        model = DKIModel(dataset, **model_kwargs)
-        assert model._model_class == "dipy.reconst.dki.DiffusionKurtosisModel"
+        assert (
+            DKIModel(dataset, **model_kwargs)._model_class
+            == "dipy.reconst.dki.DiffusionKurtosisModel"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix miscellaneous type check errors:
- Do not create a `model` variable that may take two types, and query directy the model class immediately after the constructor call to avoid warnings related to the variable taking two incompatible types across the branching logic.
- Annotate the context with an abstract manager to avoid incompatible types when assigning two different types in the branching logic.
- Annotate the dummy model `fit_predict` method to match the superclass signature types.

Fixes:
```
test/test_parser.py:270: error:
 Incompatible types in assignment (expression has type "DKIModel", variable has type "DTIModel")  [assignment]
```
and
```
test/test_model.py:76: error:
 Incompatible types in assignment (expression has type "WarningsChecker", variable has type "nullcontext[None]")  [assignment]
```

and
```
test/test_estimator.py:38: error:
 Signature of "fit_predict" incompatible with supertype "nifreeze.model.base.BaseModel"  [override]
test/test_estimator.py:38: note:
      Superclass:
test/test_estimator.py:38: note:
          def fit_predict(self, index: int | None = ..., **kwargs: Any) -> ndarray[Any, Any] | None
test/test_estimator.py:38: note:
      Subclass:
test/test_estimator.py:38: note:
          def fit_predict(self, idx: Any = ..., **kwargs: Any) -> Any
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18430904407/job/52518077604#step:8:59