### PR TITLE
STY: Fix motion visualization test figure saving type check errors

### DIFF
--- a/test/test_motion_viz.py
+++ b/test/test_motion_viz.py
@@ -27,6 +27,7 @@ import pandas as pd
 import pytest
 from dipy.data import read_stanford_hardi
 from dipy.segment.mask import median_otsu
+from matplotlib.figure import Figure
 from scipy.ndimage import affine_transform, binary_dilation
 from skimage.morphology import ball
 
@@ -63,8 +64,9 @@ def test_plot_framewise_displacement(request, tmp_path):
 
     labels = labels[:-1]
     ax = plot_framewise_displacement(fd, labels)
+    fig: Figure = ax.figure
     out_svg = tmp_path / "framewise_displacement.svg"
-    ax.figure.savefig(out_svg, format="svg")
+    fig.savefig(out_svg, format="svg")
 
 
 def test_plot_volumewise_motion(request, tmp_path):
@@ -84,8 +86,9 @@ def test_plot_volumewise_motion(request, tmp_path):
     motion_params = np.hstack([translations, rotations])
 
     ax = plot_volumewise_motion(frames, motion_params)
+    fig: Figure = ax[0].figure
     out_svg = tmp_path / "volumewise_motion.svg"
-    ax[0].figure.savefig(out_svg, format="svg")
+    fig.savefig(out_svg, format="svg")
 
 
 @pytest.mark.parametrize("orientation", ["axial", "coronal", "sagittal"])
@@ -150,5 +153,6 @@ def test_plot_motion_overlay(tmp_path, orientation):
     ax = plot_motion_overlay(
         rel_diff, dwi_dir_data, brain_mask, orientation, slice_idx, smooth=smooth
     )
+    fig: Figure = ax.figure
     out_svg = tmp_path / "motion_overlay.svg"
-    ax.figure.savefig(out_svg, format="svg")
+    fig.savefig(out_svg, format="svg")


### PR DESCRIPTION
Fix motion visualization test figure saving type check errors: get and annotatevthe figure that holds the axis to help `mypy` understand that it is a proper figure.

Fixes:
```
test/test_motion_viz.py:67: error:
 Item "SubFigure" of "Figure | SubFigure | None" has no attribute "savefig"  [union-attr]
test/test_motion_viz.py:67: error:
 Item "None" of "Figure | SubFigure | None" has no attribute "savefig"  [union-attr]
test/test_motion_viz.py:154: error:
 Item "SubFigure" of "Figure | SubFigure | None" has no attribute "savefig"  [union-attr]
test/test_motion_viz.py:154: error:
 Item "None" of "Figure | SubFigure | None" has no attribute "savefig"  [union-attr]
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18434571087/job/52526331120#step:8:57