### PR TITLE
REF: Remove unnecessary PET data `to_nifti` method

### DIFF
--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -174,12 +174,6 @@ class PET(BaseDataset[np.ndarray | None]):
                         compression_opts=compression_opts,
                     )
 
-    def to_nifti(self, filename, *_):
-        """Write a NIfTI 1.0 file to disk."""
-        nii = nb.Nifti1Image(self.dataobj, self.affine, None)
-        nii.header.set_xyzt_units("mm")
-        nii.to_filename(filename)
-
     @classmethod
     def from_filename(cls, filename: Path | str) -> Self:
         """Read an HDF5 file from disk."""


### PR DESCRIPTION
Remove unnecessary PET data `to_nifti` method: at this point, the parent class implementation can be called, as the PET data class implementation does not do any extra processes. It is verified that when serializing the PET NIfTI file, the header is `None`, and thus the units are set to mm as the current child class implementation does.

Incidentally, this fixes the type check errors:
```
src/nifreeze/data/pet.py:177:
 error: Signature of "to_nifti" incompatible with supertype "nifreeze.data.base.BaseDataset"  [override]
src/nifreeze/data/pet.py:177:
 note:      Superclass:
src/nifreeze/data/pet.py:177:
 note:          def to_nifti(self, filename: Path | str | None = ..., write_hmxfms: bool = ..., order: int = ...) -> Nifti1Image
src/nifreeze/data/pet.py:177:
 note:      Subclass:
src/nifreeze/data/pet.py:177:
 note:          def to_nifti(self, filename: Any, *_: Any) -> Any
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/18434571087/job/52526331120#step:8:39