### PR TITLE
STY: Fix miscellaneous type check errors (part 3)

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -68,7 +68,9 @@ def test_main_call(tmp_path, monkeypatch, write_hdf5):
     # Monkeypatch
     monkeypatch.setattr(cli_run.Estimator, "run", smoke_estimator_run)
 
-    input_file = Path(os.getenv("TEST_DATA_HOME")) / "dwi.h5"
+    test_data_home = os.getenv("TEST_DATA_HOME")
+    assert test_data_home is not None, "TEST_DATA_HOME must be set"
+    input_file = Path(test_data_home) / "dwi.h5"
     argv = [
         str(input_file),
         "--models",

--- a/test/test_motion_viz.py
+++ b/test/test_motion_viz.py
@@ -64,7 +64,8 @@ def test_plot_framewise_displacement(request, tmp_path):
 
     labels = labels[:-1]
     ax = plot_framewise_displacement(fd, labels)
-    fig: Figure = ax.figure
+    assert isinstance(ax.figure, Figure)
+    fig = ax.figure
     out_svg = tmp_path / "framewise_displacement.svg"
     fig.savefig(out_svg, format="svg")
 
@@ -86,7 +87,8 @@ def test_plot_volumewise_motion(request, tmp_path):
     motion_params = np.hstack([translations, rotations])
 
     ax = plot_volumewise_motion(frames, motion_params)
-    fig: Figure = ax[0].figure
+    assert isinstance(ax[0].figure, Figure)
+    fig = ax[0].figure
     out_svg = tmp_path / "volumewise_motion.svg"
     fig.savefig(out_svg, format="svg")
 
@@ -153,6 +155,7 @@ def test_plot_motion_overlay(tmp_path, orientation):
     ax = plot_motion_overlay(
         rel_diff, dwi_dir_data, brain_mask, orientation, slice_idx, smooth=smooth
     )
-    fig: Figure = ax.figure
+    assert isinstance(ax.figure, Figure)
+    fig = ax.figure
     out_svg = tmp_path / "motion_overlay.svg"
     fig.savefig(out_svg, format="svg")


### PR DESCRIPTION
Fix miscellaneous type check errors:
- Assert that an axis figure attribute is a `Figure` instance rather than annotating its type. Fixes a type check error introduced in commit 3c9f597.
- Ensure that the `TEST_DATA_HOME` environment variable is not `None`before converting it to a `Path` instance.

Fixes:
```
test/test_motion_viz.py:67: error:
 Incompatible types in assignment (expression has type "Figure | SubFigure", variable has type "Figure")  [assignment]
test/test_motion_viz.py:156: error:
 Incompatible types in assignment (expression has type "Figure | SubFigure", variable has type "Figure")  [assignment]
```

and
```
test/test_main.py:71: error:
 Argument 1 to "Path" has incompatible type "str | None"; expected "str | PathLike[str]"  [arg-type]
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18445645344/job/52551975423?pr=273#step:8:57 and
https://github.com/nipreps/nifreeze/actions/runs/18445645344/job/52551975423?pr=273#step:8:59