### PR TITLE
STY: Fix miscellaneous type checking errors (part 4)

### DIFF
--- a/benchmarks/benchmarks/bench_model.py
+++ b/benchmarks/benchmarks/bench_model.py
@@ -97,7 +97,10 @@ class DiffusionGPRBenchmark(ABC):
         self._y_test = y[:, train_test_mask]
 
     def time_fit(self, *args):
+        assert self._estimator is not None
+        assert self._y_train is not None
         self._estimator = self._estimator.fit(self._X_train, self._y_train.T)
 
     def time_predict(self):
+        assert self._estimator is not None
         self._estimator.predict(self._X_test)

--- a/src/nifreeze/testing/simulations.py
+++ b/src/nifreeze/testing/simulations.py
@@ -407,7 +407,7 @@ def simulate_multifiber_voxels(S0, hsph_dirs, bval_shell=1000, snr=20, n_voxels=
         signal.append(_signal)
 
     # Shuffle voxels
-    signal = rng.permutation(np.vstack(signal))
+    signal = rng.permutation(np.vstack(signal)).tolist()
 
     return signal, gtab
 

--- a/src/nifreeze/viz/signals.py
+++ b/src/nifreeze/viz/signals.py
@@ -132,6 +132,8 @@ def calculate_sphere_pts(points, center):
     kdtree = KDTree(points)  # tree of nearest points
     # d is an array of distances, i is an array of indices
     d, i = kdtree.query(center, points.shape[0])
+    d = np.atleast_1d(d)
+    i = np.atleast_1d(i)
     sphere_pts = np.zeros(points.shape, dtype=float)
 
     radius = np.amax(d)

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -89,7 +89,7 @@ def test_advanced_clip(
     assert (
         np.allclose(data, expected_output, atol=1e-6)
         if inplace
-        else np.allclose(clipped_data, expected_output, atol=1e-6)
+        else np.allclose(clipped_data, expected_output, atol=1e-6)  # type: ignore[arg-type]
     )
 
 
@@ -166,7 +166,7 @@ def test_grand_mean_normalization(setup_random_uniform_ndim_data, use_mask, cent
     assert (
         np.allclose(data, expected_output, atol=1e-6)
         if inplace
-        else np.allclose(normalized_data, expected_output, atol=1e-6)
+        else np.allclose(normalized_data, expected_output, atol=1e-6)  # type: ignore[arg-type]
     )
 
 
@@ -211,5 +211,5 @@ def test_robust_minmax_normalization(
     assert (
         np.allclose(data, expected_output, atol=1e-6)
         if inplace
-        else np.allclose(normalized_data, expected_output, atol=1e-6)
+        else np.allclose(normalized_data, expected_output, atol=1e-6)  # type: ignore[arg-type]
     )

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -66,7 +66,7 @@ def test_trivial_model(request, use_mask):
 
     # Should not allow initialization without an oracle
     with pytest.raises(TypeError):
-        model.TrivialModel()
+        model.TrivialModel()  # type: ignore[call-arg]
 
     size = (2, 2, 2)
     mask = None


### PR DESCRIPTION
Fix miscellaneous type checking errors:
- Convert the result of the signal permutation back to a list when creating multifiber voxel signals. The variable being initialized as an empty list forces the type checking to keep the original type.
- Ignore the `np.allclose` argument checking. When `inplace` is `True` the resulting value of the function call will be `None`; the type checking, being a static check, raises the error, even if it the test is protected by a conditional statement. Ignoring the the error is safe in this case.
- Ensure that we have at least a 1D arrays for the kdtree query return values before indexing them as they may be scalars.
- Ignore calling the trivial model without the required dataset argument: the test intends to explicitly check that the parameter is needed.
- Ensure that the attributes of the benchmarking class are not `None` prior to measuring the fitting time in benchmarking. Attributes are initialized to `None`, and even if a proper setup method to assing values and instantiate object is called before fitting, `mypy` performs an static check and thus believes that they may be `None` when querying about their attributes. This patch set ensures that attributes are called on proper values.

Fixes:
```
src/nifreeze/testing/simulations.py:410: error:
 Incompatible types in assignment (expression has type "ndarray[Any, Any]",
 variable has type "list[Any]")  [assignment]
```

and
```
test/test_filtering.py:92: error:
 Argument 1 to "allclose" has incompatible type "ndarray[Any, Any] | None";
 expected "Buffer | _SupportsArray[dtype[Any]] | _NestedSequence[_SupportsArray[dtype[Any]]]
 | bool | int | float | complex | str | bytes | _NestedSequence[bool | int | float | complex | str | bytes]"  [arg-type]
test/test_filtering.py:169: error:
 Argument 1 to "allclose" has incompatible type "ndarray[Any, Any] | None";
 expected "Buffer | _SupportsArray[dtype[Any]] | _NestedSequence[_SupportsArray[dtype[Any]]]
 | bool | int | float | complex | str | bytes | _NestedSequence[bool | int | float | complex | str | bytes]"  [arg-type]
test/test_filtering.py:214: error:
 Argument 1 to "allclose" has incompatible type "ndarray[Any, Any] | None";
 expected "Buffer | _SupportsArray[dtype[Any]] | _NestedSequence[_SupportsArray[dtype[Any]]]
 | bool | int | float | complex | str | bytes | _NestedSequence[bool | int | float | complex | str | bytes]"  [arg-type]
```

and
```
src/nifreeze/viz/signals.py:139: error:
 Value of type "signedinteger[Any] | ndarray[tuple[Any, ...], dtype[signedinteger[Any]]]" is not indexable  [index]
src/nifreeze/viz/signals.py:139: error:
 Value of type "float | ndarray[tuple[Any, ...], dtype[floating[_64Bit]]]" is not indexable  [index]
```

and
```
test/test_model.py:69: error:
 Missing positional argument "dataset" in call to "TrivialModel"  [call-arg]
```

and
```
benchmarks/benchmarks/bench_model.py:100: error:
 Item "None" of "Any | None" has no attribute "fit"  [union-attr]
benchmarks/benchmarks/bench_model.py:100: error:
 Item "None" of "Any | None" has no attribute "T"  [union-attr]
benchmarks/benchmarks/bench_model.py:103: error:
 Item "None" of "Any | None" has no attribute "predict"  [union-attr]
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/18446160030/job/52553155548#step:8:40 and
https://github.com/nipreps/nifreeze/actions/runs/18446160030/job/52553155548#step:8:41 and
https://github.com/nipreps/nifreeze/actions/runs/18446160030/job/52553155548#step:8:47 and
https://github.com/nipreps/nifreeze/actions/runs/18446160030/job/52553155548#step:8:52