### PR TITLE
STY: Mark the base data class `datahdr` attribute as optional

### DIFF
--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -82,7 +82,7 @@ class BaseDataset(Generic[Unpack[Ts]]):
     """A boolean ndarray object containing a corresponding brainmask."""
     motion_affines: np.ndarray = attrs.field(default=None, eq=attrs.cmp_using(eq=_cmp))
     """List of :obj:`~nitransforms.linear.Affine` realigning the dataset."""
-    datahdr: nb.Nifti1Header = attrs.field(default=None)
+    datahdr: nb.Nifti1Header | None = attrs.field(default=None)
     """A :obj:`~nibabel.Nifti1Header` header corresponding to the data."""
 
     _filepath: Path = attrs.field(


### PR DESCRIPTION
Mark the base data class `datahdr` attribute as optional: add `None` to the the possible types it can have.

`datahdr` can take `None` values, e.g.:
https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/src/nifreeze/data/base.py#L286 https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/test/conftest.py#L312 https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/test/test_data_dmri.py#L159