### PR TITLE
REF: Remove unnecessary DWI data class `gradients` check for `None`

### DIFF
--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -75,8 +75,8 @@ class DWI(BaseDataset[np.ndarray | None]):
     eddy_xfms: list = attrs.field(default=None)
     """List of transforms to correct for estimated eddy current distortions."""
 
-    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray | None]:
-        return (self.gradients[..., idx] if self.gradients is not None else None,)
+    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray]:
+        return (self.gradients[..., idx],)
 
     # For the sake of the docstring
     def __getitem__(


### PR DESCRIPTION
Remove unnecessary DWI data class `gradients` attribute check for `None` values: `gradients` is a necessary piece of information for the class and thus, cannot be `None`: when reading a DWI sequence, it is ultimately set at
https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/src/nifreeze/data/dmri.py#L386