### PR TITLE
STY: Assign unused parameter to unnamed variable

### DIFF
--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -100,6 +100,20 @@ class BaseDataset(Generic[Unpack[Ts]]):
         return self.dataobj.shape[-1]
 
     def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[Unpack[Ts]]:
+        """
+        Extracts extra fields synchronized with the indexed access of the corresponding data object.
+
+        Parameters
+        ----------
+        idx : :obj:`int` or :obj:`slice` or :obj:`tuple` or :obj:`~numpy.ndarray`
+            Index (or indexing type/object) for which extra information will be extracted.
+
+        Returns
+        -------
+        :obj:`tuple`
+            A tuple with the extra fields (may be an empty tuple if no extra fields are defined).
+
+        """
         _ = idx  # Avoid unused parameter warning
         return ()  # type: ignore[return-value]
 


### PR DESCRIPTION
Assign unused parameter to unnamed variable.

Fixes:
```
Parameter 'idx' value is not used
```

raised by IDE.