### PR TITLE
REF: Use boolean types for brainmasks whenever possible

### DIFF
--- a/docs/notebooks/bold_realignment.ipynb
+++ b/docs/notebooks/bold_realignment.ipynb
@@ -90,7 +90,7 @@
     "    if not dilmask_path.exists():\n",
     "        niimsk = nb.load(bmask_path)\n",
     "        niimsk.__class__(\n",
-    "            binary_dilation(niimsk.get_fdata() > 0.0, ball(4)).astype(\"uint8\"),\n",
+    "            binary_dilation(niimsk.get_fdata() > 0.0, ball(4)).astype(np.uint8),\n",
     "            niimsk.affine,\n",
     "            niimsk.header,\n",
     "        ).to_filename(dilmask_path)\n",

--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -175,7 +175,7 @@ class Estimator:
             if dataset.brainmask is not None:
                 bmask_path = ptmp_dir / "brainmask.nii.gz"
                 nb.Nifti1Image(
-                    dataset.brainmask.astype("uint8"), dataset.affine, None
+                    dataset.brainmask.astype(np.uint8), dataset.affine, None
                 ).to_filename(bmask_path)
 
             with tqdm(total=dataset_length, unit="vols.") as pbar:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -93,7 +93,7 @@ def motion_data(tmp_path_factory, datadir):
     dwdata = DWI.from_filename(datadir / "dwi.h5")
     b0nii = nb.Nifti1Image(dwdata.bzero, dwdata.affine, None)
     masknii = (
-        nb.Nifti1Image(dwdata.brainmask.astype("uint8"), dwdata.affine, None)
+        nb.Nifti1Image(dwdata.brainmask.astype(np.uint8), dwdata.affine, None)
         if dwdata.brainmask is not None
         else None
     )
@@ -311,7 +311,7 @@ def setup_random_base_data(request):
     base_dataobj, affine = _generate_random_uniform_spatial_data(
         request, (*vol_size, volumes), 0.0, 1.0
     )
-    brainmask_dataobj = rng.choice([True, False], size=vol_size).astype(np.uint8)
+    brainmask_dataobj = rng.choice([True, False], size=vol_size).astype(bool)
     motion_affines = rng.random((volumes, 4, 4))
     datahdr = None
 
@@ -353,7 +353,7 @@ def setup_random_dwi_data(request, setup_random_gtab_data):
     dwi_dataobj, affine = _generate_random_uniform_spatial_data(
         request, (*vol_size, volumes), 0.0, 1.0
     )
-    brainmask_dataobj = rng.choice([True, False], size=vol_size).astype(np.uint8)
+    brainmask_dataobj = rng.choice([True, False], size=vol_size).astype(bool)
     b0_dataobj = rng.random(vol_size, dtype="float32")
     gradients = np.vstack([bvecs, bvals[np.newaxis, :]], dtype="float32")
 

--- a/test/test_data_dmri.py
+++ b/test/test_data_dmri.py
@@ -205,7 +205,7 @@ def test_equality_operator(tmp_path, setup_random_dwi_data):
     dwi, brainmask, b0 = _dwi_data_to_nifti(
         dwi_dataobj,
         affine,
-        brainmask_dataobj,
+        brainmask_dataobj.astype(np.uint8),
         b0_dataobj,
     )
 


### PR DESCRIPTION
Use boolean types for brainmasks whenever possible: makes the implementation match the attribute documentation:
https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/src/nifreeze/data/base.py#L82

Note that `nibabel` does not support at this time boolean types when building a `NIfTI` image instance or when serializing data. Thus, the related statements remain unchanged or have been adapted to use `np.uint8`.