### PR TITLE
STY: Fix `motion_affines` type annotation

### DIFF
--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -80,8 +80,8 @@ class BaseDataset(Generic[Unpack[Ts]]):
     """Best affine for RAS-to-voxel conversion of coordinates (NIfTI header)."""
     brainmask: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A boolean ndarray object containing a corresponding brainmask."""
-    motion_affines: np.ndarray = attrs.field(default=None, eq=attrs.cmp_using(eq=_cmp))
-    """List of :obj:`~nitransforms.linear.Affine` realigning the dataset."""
+    motion_affines: np.ndarray | None = attrs.field(default=None, eq=attrs.cmp_using(eq=_cmp))
+    """Array of :obj:`~nitransforms.linear.Affine` realigning the dataset."""
     datahdr: nb.Nifti1Header | None = attrs.field(default=None)
     """A :obj:`~nibabel.Nifti1Header` header corresponding to the data."""
 

--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -143,7 +143,7 @@ class PET(BaseDataset[np.ndarray | None]):
 
         # update transform
         if self.motion_affines is None:
-            self.motion_affines = [None] * len(self)
+            self.motion_affines = np.asarray([None] * len(self))
 
         self.motion_affines[index] = xform
 


### PR DESCRIPTION
Fix `motion_affines` type annotation: add `None` to its type annotation as it can also take that value, e.g.
https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/src/nifreeze/data/dmri.py#L242 https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/src/nifreeze/data/pet.py#L146 https://github.com/nipreps/nifreeze/blob/eebdceb0ead93abab6a68685a684ece92cdfc526/test/test_data_dmri.py#L90

Fixes:
```
test/test_data_dmri.py:88: error:
 Incompatible types in assignment (expression has type "ndarray[Any, dtype[Any]] | None",
 variable has type "ndarray[Any, Any]")  [assignment]
```

raised in
https://github.com/nipreps/nifreeze/actions/runs/18478441375/job/52648138075?pr=273#step:8:34

When not provided in the `PET` data class, build it as an array instead of as a list. Avoids:
```
src/nifreeze/data/pet.py:147: error:
 Incompatible types in assignment (expression has type "list[None]",
 variable has type "ndarray[Any, Any] | None")  [assignment]
src/nifreeze/data/pet.py:149: error:
 Unsupported target for indexed assignment ("ndarray[Any, Any] | None")  [index]
```

raised locally when adding `None` to the type annotation.

Take advantage of the commit to explicitly mark it as an array in its docstring instead of a list to avoid confusion.