### PR TITLE
STY: Mark the base data class `brainmask` attribute as optional

### DIFF
--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -78,7 +78,9 @@ class BaseDataset(Generic[Unpack[Ts]]):
     """A :obj:`~numpy.ndarray` object for the data array."""
     affine: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """Best affine for RAS-to-voxel conversion of coordinates (NIfTI header)."""
-    brainmask: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
+    brainmask: np.ndarray | None = attrs.field(
+        default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp)
+    )
     """A boolean ndarray object containing a corresponding brainmask."""
     motion_affines: np.ndarray = attrs.field(default=None, eq=attrs.cmp_using(eq=_cmp))
     """List of :obj:`~nitransforms.linear.Affine` realigning the dataset."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -92,7 +92,11 @@ def motion_data(tmp_path_factory, datadir):
 
     dwdata = DWI.from_filename(datadir / "dwi.h5")
     b0nii = nb.Nifti1Image(dwdata.bzero, dwdata.affine, None)
-    masknii = nb.Nifti1Image(dwdata.brainmask.astype("uint8"), dwdata.affine, None)
+    masknii = (
+        nb.Nifti1Image(dwdata.brainmask.astype("uint8"), dwdata.affine, None)
+        if dwdata.brainmask is not None
+        else None
+    )
 
     # Generate a list of large-yet-plausible bulk-head motion
     xfms = nt.linear.LinearTransformsMapping(

--- a/test/test_data_pet.py
+++ b/test/test_data_pet.py
@@ -140,7 +140,7 @@ def test_from_nii(tmp_path, random_nifti_file, brainmask_file, frame_time, frame
     assert pet_obj.total_duration == expected_total_duration
 
     if brainmask_file:
-        assert hasattr(pet_obj, "brainmask")
+        assert pet_obj.brainmask is not None
         np.testing.assert_array_equal(pet_obj.brainmask, mask_data)
 
 


### PR DESCRIPTION
Mark the base data class `brainmask` attribute as optional: add `None` to the possible types it can have.

Fixes:
```
test/test_model.py:91: error:
 Argument "brainmask" to "DWI" has incompatible type "ndarray[Any, dtype[Any]] | None";
 expected "ndarray[Any, Any]"  [arg-type]
```

Assign `None` when creating the brainmask data in the `motion_data` fixture in case the data stored in the testing HDF5 file has no brainmask data. Avoids:
```
test/conftest.py:95: error:
 Item "None" of "ndarray[Any, Any] | None" has no attribute "astype"  [union-attr]
```

Ensure that the brainmask is not `None` through an assertion rather than checking whether the PET object has the `brainmask` attribute. Avoids:
```
test/test_data_pet.py:145: error:
 Argument 1 to "assert_array_equal" has incompatible type "ndarray[Any, Any] | None";
 expected "_SupportsArray[dtype[Any]] | _NestedSequence[_SupportsArray[dtype[Any]]] |
 bool | int | float | complex | str | bytes | _NestedSequence[bool | int | float |
 complex | str | bytes]"  [arg-type]
```

raised locally after adding `None` to the `brainmask` type annotation.