### PR TITLE
STY: Allow `fit_predict` to return `None`

### DIFF
--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -23,7 +23,6 @@
 """Base infrastructure for nifreeze's models."""
 
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Union
 from warnings import warn
 
 import numpy as np
@@ -104,7 +103,7 @@ class BaseModel(ABC):
             warn(mask_absence_warn_msg, stacklevel=2)
 
     @abstractmethod
-    def fit_predict(self, index: int | None = None, **kwargs) -> Union[np.ndarray, None]:
+    def fit_predict(self, index: int | None = None, **kwargs) -> np.ndarray | None:
         """
         Fit and predict the indicated index of the dataset (abstract signature).
 


### PR DESCRIPTION
Allow `fit_predict` to return `None` as the `_locked_fit` attribute can be `None`: add `None` to the return type annotations of the method.

Fixes:
```
src/nifreeze/model/base.py:147: error:
 Incompatible return value type (got "Any | None",
 expected "ndarray[Any, Any]")  [return-value]
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/18478441375/job/52648138075?pr=273#step:8:35