### PR TITLE
REF: Refactor the `get_extra` attribute to return an array or `None`

### DIFF
--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -99,12 +99,12 @@ class BaseDataset(Generic[Unpack[Ts]]):
 
         return self.dataobj.shape[-1]
 
-    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[Unpack[Ts]]:
-        return ()  # type: ignore[return-value]
+    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> np.ndarray | None:
+        return None
 
     def __getitem__(
         self, idx: int | slice | tuple | np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray | None, Unpack[Ts]]:
+    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None]:
         """
         Returns volume(s) and corresponding affine(s) through fancy indexing.
 
@@ -127,7 +127,7 @@ class BaseDataset(Generic[Unpack[Ts]]):
             raise ValueError("No data available (dataobj is None).")
 
         affine = self.motion_affines[idx] if self.motion_affines is not None else None
-        return self.dataobj[..., idx], affine, *self._getextra(idx)
+        return self.dataobj[..., idx], affine, self._getextra(idx)
 
     @property
     def shape3d(self):

--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -75,8 +75,8 @@ class DWI(BaseDataset[np.ndarray | None]):
     eddy_xfms: list = attrs.field(default=None)
     """List of transforms to correct for estimated eddy current distortions."""
 
-    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray | None]:
-        return (self.gradients[..., idx] if self.gradients is not None else None,)
+    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> np.ndarray | None:
+        return self.gradients[..., idx] if self.gradients is not None else None
 
     # For the sake of the docstring
     def __getitem__(

--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -52,8 +52,8 @@ class PET(BaseDataset[np.ndarray | None]):
     uptake: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A (N,) numpy array specifying the uptake value of each sample or frame."""
 
-    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> tuple[np.ndarray | None]:
-        return (self.midframe[idx] if self.midframe is not None else None,)
+    def _getextra(self, idx: int | slice | tuple | np.ndarray) -> np.ndarray | None:
+        return self.midframe[idx] if self.midframe is not None else None
 
     # For the sake of the docstring
     def __getitem__(

--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -73,15 +73,17 @@ def test_getitem_volume_index(random_dataset: BaseDataset):
     By default, motion_affines is None, so we expect to get None for the affine.
     """
     # Single volume  # Note that the type ignore can be removed once we can use *Ts
-    volume0, aff0 = random_dataset[0]  # type: ignore[misc]  # PY310
+    volume0, aff0, extra0 = random_dataset[0]  # type: ignore[misc]  # PY310
     assert volume0.shape == (32, 32, 32)
     # No transforms have been applied yet, so there's no motion_affines array
     assert aff0 is None
+    assert extra0 is None
 
     # Slice of volumes
-    volume_slice, aff_slice = random_dataset[2:4]  # type: ignore[misc]  # PY310
+    volume_slice, aff_slice, extra_slice = random_dataset[2:4]  # type: ignore[misc]  # PY310
     assert volume_slice.shape == (32, 32, 32, 2)
     assert aff_slice is None
+    assert extra_slice is None
 
 
 def test_set_transform(random_dataset: BaseDataset):
@@ -96,7 +98,7 @@ def test_set_transform(random_dataset: BaseDataset):
     random_dataset.set_transform(idx, affine)
 
     # Data shouldn't have changed (since transform is identity).
-    volume0, aff0 = random_dataset[idx]  # type: ignore[misc]  # PY310
+    volume0, aff0, extra0 = random_dataset[idx]  # type: ignore[misc]  # PY310
     assert np.allclose(data_before, volume0)
 
     # motion_affines should be created and match the transform matrix.
@@ -105,6 +107,8 @@ def test_set_transform(random_dataset: BaseDataset):
     # The returned affine from __getitem__ should be the same.
     assert aff0 is not None
     np.testing.assert_array_equal(aff0, affine)
+
+    assert extra0 is None
 
 
 def test_to_filename_and_from_filename(random_dataset: BaseDataset):


### PR DESCRIPTION
Refactor the `get_extra` attribute to return an array or `None` instead of a tuple: the derivative classes can only return an array as the values they return can only be arrays, and the base class must return `None` to remain generic and as it does not store any extra property.

Thus, there is no need to unpack the extras in the base class `__getitem__` method.