### PR TITLE
STY: Fix `Trivial` model test typing

### DIFF
--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -27,9 +27,10 @@ from warnings import warn
 
 import numpy as np
 
-mask_absence_warn_msg = (
+MASK_ABSENCE_WARN_MSG = (
     "No mask provided; consider using a mask to avoid issues in model optimization."
 )
+"""Mask warning message."""
 PREDICTED_MAP_ERROR_MSG = "This model requires the predicted map at initialization"
 """Oracle requirement error message."""
 UNSUPPORTED_MODEL_ERROR_MSG = "Unsupported model <{model}>."
@@ -104,7 +105,7 @@ class BaseModel(ABC):
         self._dataset = dataset
         # Warn if mask not present
         if dataset.brainmask is None:
-            warn(mask_absence_warn_msg, stacklevel=2)
+            warn(MASK_ABSENCE_WARN_MSG, stacklevel=2)
 
     @abstractmethod
     def fit_predict(self, index: int | None = None, **kwargs) -> np.ndarray | None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -40,9 +40,9 @@ from nifreeze.data.dmri import (
 )
 from nifreeze.model._dipy import GaussianProcessModel
 from nifreeze.model.base import (
+    MASK_ABSENCE_WARN_MSG,
     PREDICTED_MAP_ERROR_MSG,
     UNSUPPORTED_MODEL_ERROR_MSG,
-    mask_absence_warn_msg,
 )
 from nifreeze.testing import simulations as _sim
 
@@ -98,7 +98,7 @@ def test_trivial_model(request, use_mask):
         mask = np.ones(size, dtype=bool)
         context = contextlib.nullcontext()
     else:
-        context = pytest.warns(UserWarning, match=mask_absence_warn_msg)
+        context = pytest.warns(UserWarning, match=MASK_ABSENCE_WARN_MSG)
 
     _S0 = rng.normal(size=size)
 


### PR DESCRIPTION
- STY: Create dataset without oracle to test `Trivial` model error
- REF: Define the `Trivial` model oracle error message for reuse in test
- STY: Capitalize the mask warning message variable name