### PR TITLE
STY: Annotate DWI optional data class parameters as such

### DIFF
--- a/src/nifreeze/data/dmri.py
+++ b/src/nifreeze/data/dmri.py
@@ -68,7 +68,9 @@ DTI_MIN_ORIENTATIONS = 6
 class DWI(BaseDataset[np.ndarray]):
     """Data representation structure for dMRI data."""
 
-    bzero: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
+    bzero: np.ndarray | None = attrs.field(
+        default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp)
+    )
     """A *b=0* reference map, preferably obtained by some smart averaging."""
     gradients: np.ndarray = attrs.field(default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp))
     """A 2D numpy array of the gradient table (``N`` orientations x ``C`` components)."""
@@ -284,7 +286,7 @@ class DWI(BaseDataset[np.ndarray]):
                     stacklevel=2,
                 )
         else:
-            data = np.concatenate((self.bzero[..., np.newaxis], self.dataobj), axis=-1)
+            data = np.concatenate((self.bzero[..., np.newaxis], self.dataobj), axis=-1)  # type: ignore
             nii = nb.Nifti1Image(data, nii.affine, nii.header)
 
             if filename is not None:

--- a/test/test_data_dmri.py
+++ b/test/test_data_dmri.py
@@ -122,6 +122,8 @@ def test_load(datadir, tmp_path, insert_b0, rotate_bvecs):  # noqa: C901
         )
 
     if insert_b0:
+        assert dwi_h5.bzero is not None
+        assert dwi_from_nifti1.bzero is not None
         assert np.allclose(dwi_h5.bzero, dwi_from_nifti1.bzero)
 
     assert np.allclose(dwi_h5.bvals, dwi_from_nifti1.bvals, atol=1e-3)
@@ -146,6 +148,8 @@ def test_load(datadir, tmp_path, insert_b0, rotate_bvecs):  # noqa: C901
     if not rotate_bvecs:  # If we set motion_affines, data WILL change
         assert np.allclose(dwi_h5.dataobj, dwi_from_nifti2.dataobj)
     if insert_b0:
+        assert dwi_h5.bzero is not None
+        assert dwi_from_nifti2.bzero is not None
         assert np.allclose(dwi_h5.bzero, dwi_from_nifti2.bzero)
 
     assert np.allclose(dwi_h5.gradients, dwi_from_nifti2.gradients)
@@ -173,6 +177,8 @@ def test_load(datadir, tmp_path, insert_b0, rotate_bvecs):  # noqa: C901
     if not rotate_bvecs:  # If we set motion_affines, data WILL change
         assert np.allclose(dwi_h5.dataobj, dwi_from_nifti3.dataobj)
 
+    assert dwi_h5.bzero is not None
+    assert dwi_from_nifti3.bzero is not None
     assert np.allclose(dwi_h5.bzero, dwi_from_nifti3.bzero)
     assert np.allclose(dwi_h5.gradients, dwi_from_nifti3.gradients, atol=1e-6)
     assert np.allclose(dwi_h5.bvals, dwi_from_nifti3.bvals, atol=1e-6)
@@ -184,6 +190,7 @@ def test_load(datadir, tmp_path, insert_b0, rotate_bvecs):  # noqa: C901
     if not rotate_bvecs:  # If we set motion_affines, data WILL change
         assert np.allclose(dwi_h5.dataobj, dwi_from_nifti4.dataobj)
 
+    assert dwi_from_nifti4.bzero is not None
     assert np.allclose(dwi_h5.bzero, dwi_from_nifti4.bzero)
     assert np.allclose(dwi_h5.gradients, dwi_from_nifti4.gradients)
     assert np.allclose(dwi_h5.bvals, dwi_from_nifti4.bvals, atol=1e-6)


### PR DESCRIPTION
Annotate DWI optional data class parameters as such: add `None` to the type annotation of `bzero` and `eddy_xfms` attributes.

Ignore the `bzero` indexing static checking error when serializing the data to NIfTI: the indexing operation is protected by a conditional `no_bzero` statement, so at that point the class instance is bound to have a non-`None` `bzero` attribute value.

Assert that `bzero` is not `None` in tests to avoid static type checking errors.