### PR TITLE
TST: Fix dummy dataset dunder methods in estimator test

### DIFF
--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -47,11 +47,11 @@ class DummyDataset(BaseDataset):
         self.affine = np.eye(4)
 
     def __len__(self):
-        return len(self.dataobj)
+        return self.dataobj.shape[-1]
 
     def __getitem__(self, idx):
         # Return a valid 3D array and a dummy value
-        return self.dataobj[idx], 1
+        return self.dataobj[..., idx], None
 
     def set_transform(self, idx, matrix):
         pass


### PR DESCRIPTION
Fix dummy dataset dunder methods in estimator test:
- Return the correct dataset length: the length is the value along the last dimension.
- Return the correct volume given an index: the index value indexes the dataset along the last axis.

Take advantage of the commit to return `None` as the value for the motion affines, as it can either be an array or `None`, not a scalar.