### PR TITLE
STY: Ignore test comparison type errors

### DIFF
--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -105,7 +105,7 @@ def test_compute_bland_altman_features(request):
     assert np.isscalar(std_diff)
     assert np.isscalar(loa_lower)
     assert np.isscalar(loa_upper)
-    assert loa_lower < loa_upper
+    assert loa_lower < loa_upper  # type: ignore
     assert np.isscalar(ci_mean)
     assert np.isscalar(ci_loa)
 


### PR DESCRIPTION
Ignore test comparison type errors: the left and right operands have the same float types.

Ignores
```
test/test_analysis.py:108: error: Unsupported left operand type for < ("generic[Any]")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for > ("str" and "generic[Any]")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for > ("bytes" and "generic[Any]")  [operator]
test/test_analysis.py:108: error: Unsupported left operand type for < ("complex")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for > ("str" and "complex")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for > ("bytes" and "complex")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("str" and "generic[Any]")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("str" and "complex")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("str" and "bytes")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("str" and "memoryview[int]")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("bytes" and "generic[Any]")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("bytes" and "complex")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for < ("bytes" and "str")  [operator]
test/test_analysis.py:108: error: Unsupported left operand type for < ("memoryview[int]")  [operator]
test/test_analysis.py:108: error: Unsupported operand types for > ("str" and "memoryview[int]")  [operator]
test/test_analysis.py:108: note: Both left and right operands are unions
```

raised for example in
https://github.com/nipreps/nifreeze/actions/runs/18876741444/job/53868409368?pr=265#step:8:51