### PR TITLE
FIX: Add libitk version to conda install command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           # Override libiconv pre-installed from anaconda channel
           # See https://github.com/conda-forge/libitk-feedstock/issues/98
           # Since we're not creating a new environment, we must be explicit
-          conda install -c conda-forge ants=2.5 libiconv
+          conda install -c conda-forge ants=2.5 libiconv libitk=5.4.0
       - name: Verify antsRegistration path
         run: |
           export PATH=$ANTSPATH:$PATH


### PR DESCRIPTION
Updated conda install command to include libitk version.

Resolves #309.