### PR TITLE
FIX: Disallow the estimator to iterate over mock data

### DIFF
--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -103,11 +103,18 @@ def test_estimator_init_model_instance(request):
 
 def test_estimator_init_model_string(request, monkeypatch):
     rng = request.node.rng
+
     # Patch ModelFactory.init to return DummyModel
     monkeypatch.setattr(
         "nifreeze.model.base.ModelFactory.init",
         lambda model, dataset, **kwargs: DummyModel(dataset=dataset),
     )
+
+    def mock_iterator(*_, **kwargs):
+        return []
+
+    monkeypatch.setattr(iterators, "random_iterator", mock_iterator)  # Avoid iterator issues
+
     model_name = "dummy"
     est = Estimator(model=model_name, model_kwargs={})
     _dataset = DummyDataset(rng)


### PR DESCRIPTION
For some reason, our tests are sometimes trying to execute the full estimator loop even on mock data.

By mocking the iterator (which now returns an empty list in the offending test), we can now call ``run()`` on the estimator and it returns without iterating over the dataset.

While this does not address the fundamental issue of the test (which is a bit unclear, as it is not immediate that testing whether the estimator generates the right model through the factory is part of the estimators' responsibilities), at least the ``run()`` member returns a lot earlier (and what's critical, without attempting to run ANTs' ``antsRegistration``).

Resolves #309.