### PR TITLE
Use monkeypatch for estimator registration stub

### DIFF
--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -184,7 +184,11 @@ def test_estimator_iterator_index_match(
     class DummyXForm:
         matrix = np.eye(4)
 
-    nifreeze.estimator._run_registration = lambda *a, **k: DummyXForm()
+    monkeypatch.setattr(
+        nifreeze.estimator,
+        "_run_registration",
+        lambda *a, **k: DummyXForm(),
+    )
 
     model = DummyModel(dataset=dataset)
     estimator = Estimator(model, strategy=strategy)


### PR DESCRIPTION
## Summary
- ensure the estimator iterator test stubs `_run_registration` using `monkeypatch.setattr` so the helper is restored after the test

## Testing
- pytest test/test_estimator.py -k test_estimator_iterator_index_match *(fails: ModuleNotFoundError: No module named 'nifreeze._version')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145448903c83308edae28391e3d742)