### PR TITLE
FIX: Refactor registration patching with monkeypatch

### DIFF
--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -184,7 +184,11 @@ def test_estimator_iterator_index_match(
     class DummyXForm:
         matrix = np.eye(4)
 
-    nifreeze.estimator._run_registration = lambda *a, **k: DummyXForm()
+    monkeypatch.setattr(
+        nifreeze.estimator,
+        "_run_registration",
+        lambda *a, **k: DummyXForm(),
+    )
 
     model = DummyModel(dataset=dataset)
     estimator = Estimator(model, strategy=strategy)


### PR DESCRIPTION
This mock potentially overloaded the _run_registration method for all tests run within the same thread.