### PR TITLE
FIX: Use the number of levels for overriding settings control branch

### DIFF
--- a/src/nifreeze/registration/ants.py
+++ b/src/nifreeze/registration/ants.py
@@ -398,7 +398,7 @@ def generate_command(
         elif key not in PARAMETERS_SINGLE_LIST:
             continue
 
-        if levels == 1:
+        if nlevels == 1:
             settings[key] = [value]
         else:
             settings[key][-1] = value


### PR DESCRIPTION
Use the number of levels instead of the set of levels for overriding settings control branch: makes single-level settings be nested into lists.