### PR TITLE
TEST: Expand dataset coverage

### DIFF
--- a/test/data/dmri/test_base.py
+++ b/test/data/dmri/test_base.py
@@ -1,0 +1,93 @@
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+"""Tests for :mod:`nifreeze.data.dmri.base`."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from nifreeze.data.dmri.base import DWI, validate_gradients
+
+
+def _build_dwi(data, gradients):
+    return DWI(dataobj=data, affine=np.eye(4), gradients=gradients)
+
+
+def test_validate_gradients_errors():
+    with pytest.raises(ValueError):
+        validate_gradients(None, None, np.zeros((2, 3)))
+
+    bad = np.array([[0.0, 0.0, 0.0, np.nan]])
+    with pytest.raises(ValueError):
+        validate_gradients(None, None, bad)
+
+
+def test_dwi_post_init_branches():
+    data = np.zeros((2, 2, 2, 1), dtype=np.float32)
+    gradients = np.zeros((2, 4), dtype=float)
+    with pytest.raises(ValueError):
+        _build_dwi(data, gradients)
+
+    data = np.zeros((2, 2, 2, 8), dtype=np.float32)
+    gradients = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 20.0],
+            [1.0, 0.0, 0.0, 1200.0],
+            [0.0, 1.0, 0.0, 1500.0],
+            [0.0, 0.0, 1.0, 1600.0],
+            [1.0, 0.0, 0.0, 1700.0],
+            [0.0, 1.0, 1.0, 1800.0],
+            [1.0, 1.0, 0.0, 1900.0],
+        ]
+    )
+    dwi = _build_dwi(data, gradients)
+    assert dwi.bzero.shape == data.shape[:3]
+    assert dwi.dataobj.shape[-1] == 6
+    assert dwi.gradients.shape[0] == 6
+
+    few_gradients = np.array([[0.0, 0.0, 1.0, 1000.0]])
+    with pytest.raises(ValueError):
+        _build_dwi(np.zeros((2, 2, 2, 1), dtype=np.float32), few_gradients)
+
+
+def test_get_shells_and_io(tmp_path, monkeypatch):
+    data = np.zeros((2, 2, 2, 7), dtype=np.float32)
+    gradients = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 1000.0],
+            [0.0, 1.0, 0.0, 1100.0],
+            [1.0, 0.0, 1.0, 1200.0],
+            [0.0, 1.0, 1.0, 1300.0],
+            [1.0, 1.0, 0.0, 1400.0],
+            [1.0, 1.0, 1.0, 1500.0],
+        ]
+    )
+    dwi = _build_dwi(data, gradients)
+
+    monkeypatch.setattr(
+        "nifreeze.data.dmri.base.find_shelling_scheme",
+        lambda bvals, num_bins, multishell_nonempty_bin_count_thr, bval_cap: (
+            "multi-shell",
+            [np.array([1000.0, 1100.0, 1200.0]), np.array([1300.0, 1400.0, 1500.0])],
+            [1100.0, 1400.0],
+        ),
+    )
+    shells = dwi.get_shells(num_bins=5, multishell_nonempty_bin_count_thr=2, bval_cap=3000)
+    assert len(shells) == 2
+    assert shells[0][0] == 1100.0
+    np.testing.assert_array_equal(shells[0][1], np.array([0, 1, 2]))
+    assert shells[1][0] == 1400.0
+    np.testing.assert_array_equal(shells[1][1], np.array([3, 4, 5]))
+
+    out_file = tmp_path / "dwi.h5"
+    dwi.to_filename(out_file)
+    with h5py.File(out_file, "r") as h5file:
+        assert h5file.attrs["Type"] == "dmri"
+
+    reloaded = DWI.from_filename(out_file)
+    np.testing.assert_array_equal(reloaded.dataobj, dwi.dataobj)
+    np.testing.assert_array_equal(reloaded.gradients, dwi.gradients)
+

--- a/test/data/test_base_dataset.py
+++ b/test/data/test_base_dataset.py
@@ -1,0 +1,138 @@
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+"""Unit tests for :mod:`nifreeze.data.base`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pytest
+
+from nifreeze.data import NFDH5_EXT, BaseDataset
+from nifreeze.data.base import (
+    AFFINE_ABSENCE_ERROR_MSG,
+    AFFINE_NDIM_ERROR_MSG,
+    AFFINE_OBJECT_ERROR_MSG,
+    AFFINE_SHAPE_ERROR_MSG,
+    BRAINMASK_SHAPE_MISMATCH_ERROR_MSG,
+    DATAOBJ_ABSENCE_ERROR_MSG,
+    DATAOBJ_NDIM_ERROR_MSG,
+    DATAOBJ_OBJECT_ERROR_MSG,
+    validate_affine,
+    validate_dataobj,
+)
+
+
+class DummyDataset(BaseDataset):
+    """Simple subclass used to exercise equality semantics."""
+
+
+def _build_dataset(shape: tuple[int, int, int, int]) -> BaseDataset:
+    data = np.zeros(shape, dtype=np.float32)
+    return BaseDataset(dataobj=data, affine=np.eye(4))
+
+
+def test_validate_dataobj_affine_errors():
+    with pytest.raises(ValueError, match=DATAOBJ_ABSENCE_ERROR_MSG):
+        validate_dataobj(None, None, None)
+
+    with pytest.raises(TypeError, match=DATAOBJ_OBJECT_ERROR_MSG):
+        validate_dataobj(None, None, 5)
+
+    with pytest.raises(ValueError, match=DATAOBJ_NDIM_ERROR_MSG):
+        validate_dataobj(None, None, np.zeros((2, 2, 2)))
+
+    with pytest.raises(ValueError, match=AFFINE_ABSENCE_ERROR_MSG):
+        validate_affine(None, None, None)
+
+    with pytest.raises(TypeError, match=AFFINE_OBJECT_ERROR_MSG):
+        validate_affine(None, None, [[1, 0], [0, 1]])
+
+    with pytest.raises(ValueError, match=AFFINE_NDIM_ERROR_MSG):
+        validate_affine(None, None, np.ones((4,)))
+
+    with pytest.raises(ValueError, match=AFFINE_SHAPE_ERROR_MSG):
+        validate_affine(None, None, np.ones((3, 3)))
+
+
+def test_post_init_brainmask_and_handles(tmp_path):
+    data = np.zeros((2, 2, 2, 1), dtype=np.float32)
+    brainmask = np.ones((2, 2, 3), dtype=bool)
+    with pytest.raises(ValueError, match=r"^" + BRAINMASK_SHAPE_MISMATCH_ERROR_MSG.format(
+        brainmask_shape=brainmask.shape, data_shape=data.shape[:3]
+    )):
+        BaseDataset(dataobj=data, affine=np.eye(4), brainmask=brainmask)
+
+    h5_path = tmp_path / "backing.h5"
+    with h5py.File(h5_path, "w") as h5file:
+        ds = h5file.create_dataset("data", data=data)
+        dataset = BaseDataset(dataobj=ds, affine=np.eye(4))
+        assert dataset._file_handle is h5file
+        dataset.close()
+        assert dataset._file_handle is None
+
+    mmap_path = tmp_path / "backing.dat"
+    memmap = np.memmap(mmap_path, mode="w+", dtype=np.float32, shape=data.shape)
+    dataset = BaseDataset(dataobj=memmap, affine=np.eye(4))
+    assert dataset._mmap_path == mmap_path
+
+
+def test_getitem_and_equality():
+    dataset = _build_dataset((2, 2, 2, 2))
+    affine_override = np.full((4, 4), 2.0)
+    dataset.set_transform(1, affine_override)
+
+    vol, affine = dataset[1]
+    np.testing.assert_array_equal(vol, dataset.dataobj[..., 1])
+    np.testing.assert_array_equal(affine, affine_override)
+
+    other = DummyDataset(dataobj=dataset.dataobj, affine=dataset.affine)
+    assert (dataset == other) is False
+
+
+def test_hdf5_round_trip(tmp_path):
+    dataset = _build_dataset((2, 2, 2, 2))
+    out_path = tmp_path / "base_dataset"
+    dataset.to_filename(out_path)
+
+    h5_path = out_path.with_suffix(NFDH5_EXT)
+    assert h5_path.exists()
+
+    reopened = BaseDataset.from_filename(h5_path, keep_file_open=True)
+    assert isinstance(reopened.dataobj, h5py.Dataset)
+    assert reopened._file_handle is not None
+    reopened.close()
+    assert reopened._file_handle is None
+
+    reopened_eager = BaseDataset.from_filename(h5_path, keep_file_open=False)
+    assert isinstance(reopened_eager.dataobj, np.ndarray)
+    assert reopened_eager._file_handle is None
+
+
+def test_set_transform_initialization_and_to_nifti(tmp_path, monkeypatch):
+    dataset = _build_dataset((2, 2, 2, 2))
+    affine_override = np.diag([1, 2, 3, 1])
+    dataset.set_transform(0, affine_override)
+    assert dataset.motion_affines is not None
+    np.testing.assert_array_equal(dataset.motion_affines[0], affine_override)
+    np.testing.assert_array_equal(dataset.motion_affines[1], np.eye(4))
+
+    captured = []
+
+    def _fake_apply(xform, img, order):
+        captured.append((xform, order))
+        fill_value = len(captured)
+        return SimpleNamespace(dataobj=np.full(img.shape, fill_value, dtype=np.float32))
+
+    monkeypatch.setattr("nifreeze.data.base.apply", _fake_apply)
+
+    out_file = tmp_path / "resampled.nii.gz"
+    nii = BaseDataset.to_nifti(dataset, filename=out_file)
+    assert captured and out_file.exists()
+    np.testing.assert_array_equal(nii.get_fdata()[..., 0], 1)
+    np.testing.assert_array_equal(nii.get_fdata()[..., 1], 2)
+
+    with pytest.warns(UserWarning):
+        BaseDataset.to_nifti(_build_dataset((1, 1, 1, 1)), write_hmxfms=True)
+

--- a/test/data/test_pet.py
+++ b/test/data/test_pet.py
@@ -1,0 +1,105 @@
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+"""Additional PET dataset tests."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import h5py
+import nibabel as nb
+import numpy as np
+import pytest
+from nitransforms.linear import Affine
+
+from nifreeze.data.pet import PET, _compute_frame_duration
+
+
+def _make_pet(shape=(2, 2, 2, 3)) -> PET:
+    data = np.ones(shape, dtype=np.float32)
+    midframe = np.arange(shape[-1], dtype=np.float32)
+    return PET(dataobj=data, affine=np.eye(4), midframe=midframe, total_duration=float(shape[-1]))
+
+
+def test_lofo_split_creates_hdf5(tmp_path):
+    pet = _make_pet()
+    pet._filepath = tmp_path / "lofo_pet.h5"
+    assert not pet._filepath.exists()
+
+    (train_data, train_time), (test_data, test_time) = pet.lofo_split(1)
+
+    assert pet._filepath.exists()
+    assert train_data.shape[-1] == pet.dataobj.shape[-1] - 1
+    np.testing.assert_array_equal(train_time, [0, 2])
+    np.testing.assert_array_equal(test_data, pet.dataobj[..., 1])
+    assert test_time == pet.midframe[1]
+
+
+def test_pet_set_transform_updates_and_types(tmp_path, monkeypatch):
+    pet = _make_pet()
+    pet._filepath = tmp_path / "transform_pet.h5"
+
+    def _fake_apply(xform, img, order):
+        return SimpleNamespace(dataobj=np.full(img.shape, 7, dtype=np.float32))
+
+    monkeypatch.setattr("nifreeze.data.pet.apply", _fake_apply)
+
+    pet.set_transform(2, np.eye(4))
+    np.testing.assert_array_equal(pet.dataobj[..., 2], 7)
+    assert pet.motion_affines is not None
+    assert isinstance(pet.motion_affines[2], Affine)
+
+
+def test_from_filename_and_scalar_cast(tmp_path):
+    pet = _make_pet()
+    pet.total_duration = np.float32(5.5)
+    pet.to_filename(tmp_path / "pet_data.h5")
+
+    loaded = PET.from_filename(tmp_path / "pet_data.h5", keep_file_open=True)
+    assert isinstance(loaded.dataobj, h5py.Dataset)
+    assert isinstance(loaded.total_duration, float)
+    assert loaded._file_handle is not None
+    loaded.close()
+
+
+def test_load_from_nifti_and_hdf5(tmp_path):
+    data = np.stack([np.full((2, 2, 2), val, dtype=np.float32) for val in (1, 2, 3)], axis=-1)
+    affine = np.eye(4)
+    img = nb.Nifti1Image(data, affine)
+    nii_path = tmp_path / "pet.nii.gz"
+    img.to_filename(nii_path)
+
+    metadata = {"FrameDuration": [1.0, 1.0, 2.0], "FrameTimesStart": [0.0, 1.0, 2.0]}
+    json_path = tmp_path / "pet.json"
+    json_path.write_text(json.dumps(metadata))
+
+    brainmask = nb.Nifti1Image(np.ones(data.shape[:3], dtype=np.uint8), affine)
+    mask_path = tmp_path / "mask.nii.gz"
+    brainmask.to_filename(mask_path)
+
+    loaded = PET.load(nii_path, json_path, brainmask_file=mask_path)
+    np.testing.assert_array_equal(loaded.dataobj, data)
+    np.testing.assert_array_equal(loaded.midframe, np.array([0.5, 1.5, 3.0]))
+    assert loaded.total_duration == pytest.approx(4.0)
+    np.testing.assert_array_equal(loaded.brainmask, np.ones(data.shape[:3], dtype=np.uint8))
+
+    pet_h5 = tmp_path / "pet_data.h5"
+    _make_pet().to_filename(pet_h5)
+    loaded_h5 = PET.load(pet_h5, json_path)
+    assert isinstance(loaded_h5, PET)
+
+    durations = _compute_frame_duration(np.array([1.0, 3.0, 8.0], dtype=np.float32))
+    np.testing.assert_array_equal(durations, [2.0, 5.0, 5.0])
+
+
+def test_keep_file_open_scalar_conversion(tmp_path):
+    pet = _make_pet()
+    pet.total_duration = np.float32(3.25)
+    out_file = tmp_path / "keep_open.h5"
+    pet.to_filename(out_file)
+
+    loaded = PET.from_filename(out_file, keep_file_open=True)
+    assert isinstance(loaded.total_duration, float)
+    assert loaded._file_handle is not None
+    loaded.close()
+


### PR DESCRIPTION
## Summary
- add unit tests for BaseDataset validation, resource pinning, and NIfTI/HDF5 workflows
- extend PET coverage for LOFO splitting, transform handling, and loading scenarios
- cover dMRI gradient validation, shell grouping, and IO behaviors

## Testing
- pytest test/data/test_base_dataset.py test/data/test_pet.py test/data/dmri/test_base.py *(fails: missing nifreeze._version bootstrap in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925aaeebd408330858a7b24ce856d3e)