### PR TITLE
MNT: List the `attrs` dependency at a single place

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-  "attrs",
+  "attrs>=20.1.0",
   "dipy>=1.5.0",
   "joblib",
   "nipype>=1.5.1,<2.0",
@@ -42,7 +42,6 @@ NiPreps = "https://www.nipreps.org/"
 
 [project.optional-dependencies]
 doc = [
-  "attrs>=20.1.0",
   "furo>=2024.01.29",
   "matplotlib>=2.2.0",
   "nbsphinx",


### PR DESCRIPTION
List the `attrs` dependency at a single place: since it is a core dependency, it is not required to be listed as an optional dependency in the `doc` section.

Set the required minimum version to the one existing in the `doc` section.