### PR TITLE
STY: Prefer a set intersection to check for kwargs in data load

### DIFF
--- a/src/nifreeze/data/__init__.py
+++ b/src/nifreeze/data/__init__.py
@@ -72,11 +72,11 @@ def load(
 
         raise TypeError("Could not read data")
 
-    if "gradients_file" in kwargs or "bvec_file" in kwargs:
+    if {"gradients_file", "bvec_file"} & set(kwargs):
         from nifreeze.data.dmri import from_nii as dmri_from_nii
 
         return dmri_from_nii(filename, brainmask_file=brainmask_file, **kwargs)
-    elif "frame_time" in kwargs or "frame_duration" in kwargs:
+    elif {"frame_time", "frame_duration"} & set(kwargs):
         from nifreeze.data.pet import from_nii as pet_from_nii
 
         return pet_from_nii(filename, brainmask_file=brainmask_file, **kwargs)


### PR DESCRIPTION
Prefer a set intersection to check for the presence of at least one keyword argument among multiple keys in the data module `load` function. It is more compact, provides more uniform code across conditions, and scales better when checking for many keys.