### PR TITLE
TST: Include `__init__.py` files in coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,6 @@ parallel = true
 concurrency = ["multiprocessing"]
 omit = [
   "^test/*",
-  "*/__init__.py",
   "*/conftest.py",
   "src/nifreeze/_version.py"
 ]


### PR DESCRIPTION
Include `__init__.py` files in coverage report: the package's `__init__.py` files contain code (e.g. the `data` module `load` function)  that needs to be tested. If left outside coverage reports, no awareness about their exercise exists, and bugs may go unnoticed.