### PR TITLE
STY: Use underscore for unused parameter returned by function

### DIFF
--- a/src/nifreeze/data/dmri/utils.py
+++ b/src/nifreeze/data/dmri/utils.py
@@ -106,7 +106,7 @@ def find_shelling_scheme(
 
     # Bin the b-values: use -1 as the lower bound to be able to appropriately
     # include b0 values
-    hist, bin_edges = np.histogram(bvals, bins=num_bins, range=(-1, min(max(bvals), bval_cap)))
+    _, bin_edges = np.histogram(bvals, bins=num_bins, range=(-1, min(max(bvals), bval_cap)))
 
     # Collect values in each bin
     bval_groups = []


### PR DESCRIPTION
Use underscore for unused parameter returned by the `np.histogram` call in dmri data module utils `find_shelling_scheme` function. Avoids potential unused parameter warnings.