### PR TITLE
ENH: Squeeze `bzero` data to avoid unnecessary median computation call

### DIFF
--- a/src/nifreeze/data/dmri/base.py
+++ b/src/nifreeze/data/dmri/base.py
@@ -133,7 +133,7 @@ class DWI(BaseDataset[np.ndarray]):
         b0_num = np.sum(b0_mask)
 
         if b0_num > 0 and self.bzero is None:
-            bzeros = self.dataobj[..., b0_mask]
+            bzeros = self.dataobj[..., b0_mask].squeeze()
             self.bzero = bzeros if bzeros.ndim == 3 else np.median(bzeros, axis=-1)
 
         if b0_num > 0:


### PR DESCRIPTION
Squeeze `bzero` data to avoid unnecessary median computation call: in the case where the b0 is extracted from the DWI sequence (i.e. `if b0_num > 0 and self.bzero is None:` is true), if a DWI data sequence contains a single b0 volume, the statement
```
self.dataobj[..., b0_mask]
```
returns a 4D sequence where the last dimenstion is 1. This makes such that the statement
```
if bzeros.ndim == 3
```
is never evaluated to true, and `np.median` is called unnecessarily.

Sequeezing the 4D sequence makes such that the singleton dimension is removed, `bzeros.ndim == 3`  evaluates to true, and the 3D b0 data is effectively set to the `bzero` attribute without calling `np.median`.

This becomes apparent in the `test_dwi_post_init_b0_handling` and `test_to_nifti` test functions when `b0_count` is 1 and `provide_bzero` is `False`.