### PR TITLE
DOC: Add missing return type annoation across the `analysis` module

### DIFF
--- a/src/nifreeze/analysis/filtering.py
+++ b/src/nifreeze/analysis/filtering.py
@@ -25,7 +25,7 @@
 import numpy as np
 
 
-def normalize(x: np.ndarray):
+def normalize(x: np.ndarray) -> np.ndarray:
     r"""Normalize data using the z-score.
 
     The z-score normalization is computed as:

--- a/src/nifreeze/analysis/motion.py
+++ b/src/nifreeze/analysis/motion.py
@@ -22,6 +22,8 @@
 #
 """Motion analysis."""
 
+from typing import Tuple
+
 import numpy as np
 from scipy.stats import zscore
 
@@ -61,7 +63,7 @@ def compute_percentage_change(
     return rel_diff
 
 
-def identify_spikes(fd: np.ndarray, threshold: float = 2.0):
+def identify_spikes(fd: np.ndarray, threshold: float = 2.0) -> Tuple[np.ndarray, np.ndarray]:
     """Identify motion spikes in framewise displacement data.
 
     Identifies high-motion frames as timepoint exceeding a given threshold value


### PR DESCRIPTION
Add missing return type annoation across the `analysis` module.