### PR TITLE
DOC: Fix the `NiBabel` `NIfTI1` image class documentation linking

### DIFF
--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -459,7 +459,7 @@ class BaseDataset(Generic[Unpack[Ts]]):
         filename: Path | str | None = None,
         write_hmxfms: bool = False,
         order: int = 3,
-    ) -> nb.Nifti1Image:
+    ) -> nb.nifti1.Nifti1Image:
         """
         Write a NIfTI file to disk.
 
@@ -477,6 +477,10 @@ class BaseDataset(Generic[Unpack[Ts]]):
             The interpolation order to use when resampling the data.
             Defaults to 3 (cubic interpolation).
 
+        Returns
+        -------
+        :obj:`~nibabel.nifti1.Nifti1Image`
+            NIfTI image written to disk.
         """
 
         return to_nifti(
@@ -492,7 +496,7 @@ def to_nifti(
     filename: Path | str | None = None,
     write_hmxfms: bool = False,
     order: int = 3,
-) -> nb.Nifti1Image:
+) -> nb.nifti1.Nifti1Image:
     """
     Write a NIfTI file to disk.
 
@@ -512,6 +516,10 @@ def to_nifti(
         The interpolation order to use when resampling the data.
         Defaults to 3 (cubic interpolation).
 
+    Returns
+    -------
+    :obj:`~nibabel.nifti1.Nifti1Image`
+        NIfTI image written to disk.
     """
 
     if filename is None and write_hmxfms:

--- a/src/nifreeze/data/dmri/base.py
+++ b/src/nifreeze/data/dmri/base.py
@@ -274,7 +274,7 @@ class DWI(BaseDataset[np.ndarray]):
         insert_b0: bool = False,
         bvals_dec_places: int = 2,
         bvecs_dec_places: int = 6,
-    ) -> nb.Nifti1Image:
+    ) -> nb.nifti1.Nifti1Image:
         """
         Export the dMRI object to disk (NIfTI, b-vecs, & b-vals files).
 
@@ -296,6 +296,10 @@ class DWI(BaseDataset[np.ndarray]):
         bvecs_dec_places : :obj:`int`, optional
             Decimal places to use when serializing b-vectors.
 
+        Returns
+        -------
+        :obj:`~nibabel.nifti1.Nifti1Image`
+            NIfTI image written to disk.
         """
         from nifreeze.data.dmri.io import to_nifti
 

--- a/src/nifreeze/data/dmri/io.py
+++ b/src/nifreeze/data/dmri/io.py
@@ -141,7 +141,7 @@ def to_nifti(
     insert_b0: bool = False,
     bvals_dec_places: int = 2,
     bvecs_dec_places: int = 6,
-) -> nb.Nifti1Image:
+) -> nb.nifti1.Nifti1Image:
     """
     Export the dMRI object to disk (NIfTI, b-vecs, & b-vals files).
 
@@ -168,7 +168,7 @@ def to_nifti(
 
     Returns
     -------
-    nii : :obj:`~nibabel.Nifti1Image`
+    nii : :obj:`~nibabel.nifti1.Nifti1Image`
         The main DWI data object.
     """
 

--- a/src/nifreeze/data/utils.py
+++ b/src/nifreeze/data/utils.py
@@ -5,13 +5,13 @@ import nitransforms as nt
 import numpy as np
 
 
-def apply_affines(nii, em_affines, output_filename=None):
+def apply_affines(nii, em_affines, output_filename=None) -> nb.nifti1.Nifti1Image:
     """
     Apply affines to supplied nii data
 
     Parameters
     ----------
-    nii : :obj:`Nifti1Image`
+    nii : :obj:`~nibabel.nifti1.Nifti1Image`
         Nifti1Image data to be transformed
     em_affines : :obj:`ndarray`
         Nx4x4 array
@@ -20,7 +20,7 @@ def apply_affines(nii, em_affines, output_filename=None):
 
     Returns
     -------
-    nii_t_img : :obj:`Nifti1Image`
+    nii_t_img : :obj:`~nibabel.nifti1.Nifti1Image`
         Transformed Nifti1Image data
 
     """


### PR DESCRIPTION
Fix the `NiBabel` `NIfTI1` image class documentation linking: intersphinx looks up the names the upstream docs actually publish in their `objects.inv` inventory file, and `NiBabel`'s docs register the class `Nifti1Image` under the module `nibabel.nifti1` (i.e. the fully qualified name `nibabel.nifti1.Nifti1Image`). Re‑exports in `nibabel.__init__` (or `.pyi` stubs files) don't automatically produce a separate entry named `nibabel.Nifti1Image` in the upstream `objects.inv`, so the shorter/aliased names (`nb.Nifti1Image` or `nibabel.Nifti1Image`) do not resolve.

This patch set fixes the class documentation linking by adding fully qualified names to the type hints and docstrings.

Take advantage of the commit to add the related return types where missing.