### PR TITLE
REF: Make dMRI b0 handling implementation more robust

### DIFF
--- a/src/nifreeze/data/dmri/__init__.py
+++ b/src/nifreeze/data/dmri/__init__.py
@@ -48,9 +48,18 @@ The :class:`~nifreeze.data.dmri.base.DWI` class requires a ``dataobj`` that can 
 object.
 The final step of the initialization process examines the data object and the gradient table,
 and removes :math:`b=0` volumes from the data **AND** the gradient table.
+If a ``bzero`` parameter is provided, the :attr:`~nifreeze.data.dmri.base.DWI.bzero` attribute
+is set to its value. Note that a 3D volume is accepted.
 If no ``bzero`` parameter is provided, a reference low-b volume is computed as the median of all
 the low-b volumes (``b <`` :data:`~nifreeze.data.dmri.utils.DEFAULT_LOWB_THRESHOLD` s/mm²) and
 inserted in the :attr:`~nifreeze.data.dmri.base.DWI.bzero` attribute.
+If :math:`b=0` values are detected in the gradient table the :attr:`~nifreeze.data.dmri.base.DWI.dataobj`
+and :attr:`~nifreeze.data.dmri.base.DWI.gradients` attributes will have their :math:`b=0` indices
+data removed.
+If both a ``bzero`` value is provided and :math:`b=0` values are detected in the gradient
+table, the `:math:`b=0` volumes will be discarded, and the corresponding
+:attr:`~nifreeze.data.dmri.base.DWI.dataobj` and :attr:`~nifreeze.data.dmri.base.DWI.gradients`
+indices data will be removed.
 Therefore, ***NiFreeze* WILL NOT be able to reconstruct the original data organization**.
 This design choice simplifies the internal representation and processing of diffusion MRI data.
 If you want to calculate a :math:`b=0` reference map in a more sophisticated way (e.g., after

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -23,6 +23,7 @@
 """Unit tests exercising models."""
 
 import contextlib
+import warnings
 from typing import List
 
 import numpy as np
@@ -32,6 +33,7 @@ from dipy.sims.voxel import single_tensor
 from nifreeze import model
 from nifreeze.data.base import BaseDataset
 from nifreeze.data.dmri import DWI
+from nifreeze.data.dmri.base import DWI_REDUNDANT_B0_WARN_MSG
 from nifreeze.data.dmri.utils import (
     DEFAULT_LOWB_THRESHOLD,
     DEFAULT_MAX_S0,
@@ -282,13 +284,16 @@ def test_dti_model(setup_random_dwi_data):
         _,
     ) = setup_random_dwi_data
 
-    dataset = DWI(
-        dataobj=dwi_dataobj,
-        affine=affine,
-        brainmask=brainmask_dataobj,
-        bzero=b0_dataobj,
-        gradients=gradients,
-    )
+    # Ignore warning due to redundant b0 volumes
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=DWI_REDUNDANT_B0_WARN_MSG, category=UserWarning)
+        dataset = DWI(
+            dataobj=dwi_dataobj,
+            affine=affine,
+            brainmask=brainmask_dataobj,
+            bzero=b0_dataobj,
+            gradients=gradients,
+        )
 
     dtimodel = model.DTIModel(dataset)
     predicted = dtimodel.fit_predict(4)
@@ -349,13 +354,16 @@ def test_factory_avgdwi_variants(monkeypatch, name, setup_random_dwi_data):
         _,
     ) = setup_random_dwi_data
 
-    dataset = DWI(
-        dataobj=dwi_dataobj,
-        affine=affine,
-        brainmask=brainmask_dataobj,
-        bzero=b0_dataobj,
-        gradients=gradients,
-    )
+    # Ignore warning due to redundant b0 volumes
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=DWI_REDUNDANT_B0_WARN_MSG, category=UserWarning)
+        dataset = DWI(
+            dataobj=dwi_dataobj,
+            affine=affine,
+            brainmask=brainmask_dataobj,
+            bzero=b0_dataobj,
+            gradients=gradients,
+        )
 
     # Dummy class to simulate AverageDWIModel
     class DummyAvgDWI:


### PR DESCRIPTION
Make dMRI b0 handling more robust: the current implementation would set the `DWI` data class to whatever value is provided in the `bzero` argument of the constructor. This could contain multiple b0 volumes, or data whose shape does not match the shape of the DWI volumes. The first case could result in a failure when serializing the data (depending on the flags provided to the `to_nifti` function) since there would be a mismatch when trying to concatenate the b0 data and the non-null gradient data hold by the DWI instance. The second case is one that should not be allowed.

Similarly, users are not warned about the opinionated decisions that NiFreeze does when:
- Multiple `b=0` volumes are contained in the provided primary DWI data object/gradients and the median is computed.
- The primary DWI data object/gradients contain `b=0` data and a `bzero` value is provided, leading to a redundancy or discrepancy that requires to be resolved. NiFreeze would use the provided `bzero` data and discard the `b=0` in the primary DWI data object.

This patch set refactors the b0 handling at initialization to provide a consistent and predictable behavior:
- Raises an exception when the provided `bzero` data does not match the shape of the DWI volumes. Ensures that `bzero` is a 3D volume, with no additional axes.
- Warns users when multiple `b=0` volumes are contained in the provided primary DWI data object/gradients and tells them that the median value will be used as a reference.
- Warns users when `b=0` volumes are detected in the primary DWI object/gradients and a `bzero` value is provided. Tells them that the primary object `b=0` values are discarded, and the externally set `bzero` data are used to resolve the redundancy/discrepancy.
- Squeezes the `b=0` volumes extracted from the primary DWI object if a single volume exists. Thus, when a single volume is found, not attempt to compute the mean across the singleton dimension is made.

Add the necessary tests to check that the b0 data matches the above behavior, and modify the existing tests parametrization to avoid the now disallowed cases (i.e. multiple volumes in `bzero` data) and to raise or filter warnings where appropriate.

Add the necessary explanations to the `data.dmri` module documentation.