### PR TITLE
DOC: Improve documentation quality

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,6 +241,7 @@ autoclass_content = "both"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
+    "attrs": ("https://www.attrs.org/en/stable/", None),
     "bids": ("https://bids-standard.github.io/pybids/", None),
     "dipy": ("https://docs.dipy.org/stable", None),
     "matplotlib": ("https://matplotlib.org/stable", None),

--- a/scripts/simulate_pet_motion_data.py
+++ b/scripts/simulate_pet_motion_data.py
@@ -53,7 +53,7 @@ def get_affine_matrix(translation: tuple, rotation: tuple, voxel_sizes: tuple):
 
     Returns
     -------
-    affine_matrix : :obj:`numpy.ndarray`
+    affine_matrix : :obj:`~numpy.ndarray`
         Affine matrix.
     """
 

--- a/src/nifreeze/analysis/measure_agreement.py
+++ b/src/nifreeze/analysis/measure_agreement.py
@@ -60,9 +60,9 @@ def _check_bland_altman_data(data1: np.ndarray, data2: np.ndarray) -> None:
 
     Parameters
     ----------
-    data1 : :obj:`numpy.ndarray`
+    data1 : :obj:`~numpy.ndarray`
         Data values.
-    data2 : :obj:`numpy.ndarray`
+    data2 : :obj:`~numpy.ndarray`
         Data values.
     """
 
@@ -103,18 +103,18 @@ def compute_bland_altman_features(
 
     Parameters
     ----------
-    data1 : :obj:`numpy.ndarray`
+    data1 : :obj:`~numpy.ndarray`
         Data values.
-    data2 : :obj:`numpy.ndarray`
+    data2 : :obj:`~numpy.ndarray`
         Data values.
     ci : :obj:`float`
         Confidence interval size. Must be in the [0, 1] range.
 
     Returns
     -------
-    diff : :obj:`numpy.ndarray`
+    diff : :obj:`~numpy.ndarray`
         Differences.
-    mean : :obj:`numpy.ndarray`
+    mean : :obj:`~numpy.ndarray`
         Mean values (across both data arrays).
     mean_diff : :obj:`float`
         Mean differences.
@@ -181,7 +181,7 @@ def get_reliability_mask(diff: np.ndarray, loa_lower: float, loa_upper: float) -
 
     Parameters
     ----------
-    diff : :obj:`numpy.ndarray`
+    diff : :obj:`~numpy.ndarray`
         Differences data.
     loa_lower : :obj:`float`
         Lower limit of agreement.
@@ -190,7 +190,7 @@ def get_reliability_mask(diff: np.ndarray, loa_lower: float, loa_upper: float) -
 
     Returns
     -------
-    :obj:`numpy.ndarray`
+    :obj:`~numpy.ndarray`
         Reliability mask.
     """
 
@@ -212,9 +212,9 @@ def identify_bland_altman_salient_data(
 
     Parameters
     ----------
-    data1 : :obj:`numpy.ndarray`
+    data1 : :obj:`~numpy.ndarray`
         Data array 1.
-    data2 : :obj:`numpy.ndarray`
+    data2 : :obj:`~numpy.ndarray`
         Data array 2.
     ci : :obj:`float`
         Confidence interval.
@@ -227,7 +227,7 @@ def identify_bland_altman_salient_data(
     -------
     :obj:`dict`
         Reliability, left- and right-most data point indices, and corresponding
-        data masks as specified by the `:obj:`~nifreeze.analysis.measure_agreement.BASalientEntity`
+        data masks as specified by the :obj:`~nifreeze.analysis.measure_agreement.BASalientEntity`
         keys.
     """
 

--- a/src/nifreeze/cli/parser.py
+++ b/src/nifreeze/cli/parser.py
@@ -177,7 +177,7 @@ def _determine_single_fit_mode(model_name: str) -> bool:
     Returns
     -------
     :obj:`bool`
-        ``True`` if the model is to be run in *single-fit mode*, ``False``
+        :obj:`True` if the model is to be run in *single-fit mode*, :obj:`False`
         otherwise.
     """
 

--- a/src/nifreeze/data/base.py
+++ b/src/nifreeze/data/base.py
@@ -70,7 +70,7 @@ BRAINMASK_SHAPE_MISMATCH_ERROR_MSG = "BaseDataset 'brainmask' shape ({brainmask_
 
 
 def _has_dim_size(value: Any, size: int) -> bool:
-    """Return ``True`` if ``value`` has a ``.shape`` attribute and one of its
+    """Return :obj:`True` if ``value`` has a ``.shape`` attribute and one of its
      dimensions equals ``size``.
 
     This is useful for checks where at least one axis must match an expected
@@ -79,17 +79,17 @@ def _has_dim_size(value: Any, size: int) -> bool:
 
     Parameters
     ----------
-     value : :obj:`Any`
+    value : :obj:`Any`
         Object to inspect. Typical inputs are NumPy arrays or objects exposing
         ``.shape``.
-     size : :obj:`int`
+    size : :obj:`int`
         The required dimension size to look for in ``value.shape``.
 
     Returns
     -------
      :obj:`bool`
-        ``True`` if ``.shape`` exists and any of its integers equals ``size``,
-        ``False`` otherwise.
+        :obj:`True` if ``.shape`` exists and any of its integers equals ``size``,
+        :obj:`False` otherwise.
 
     Examples
     --------
@@ -112,8 +112,8 @@ def _has_dim_size(value: Any, size: int) -> bool:
 def _has_ndim(value: Any, ndim: int) -> bool:
     """Check if ``value`` has ``ndim`` dimensionality.
 
-    Returns ``True`` if `value` has an ``.ndim`` attribute equal to ``ndim``, or
-    if it has a ``.shape`` attribute whose length equals ``ndim``.
+    Returns :obj:`True` if `value` has an ``.ndim`` attribute equal to ``ndim``,
+    or if it has a ``.shape`` attribute whose length equals ``ndim``.
 
     This helper is tolerant: it accepts objects that either:
     - expose an integer ``.ndim`` attribute (e.g., NumPy arrays), or
@@ -131,8 +131,8 @@ def _has_ndim(value: Any, ndim: int) -> bool:
     Returns
     -------
     :obj:`bool`
-        ``True`` if ``value`` appears to have ``ndim`` dimensions, ``False``
-        otherwise.
+        :obj:`True` if ``value`` appears to have ``ndim`` dimensions,
+        :obj:`False` otherwise.
 
     Examples
     --------
@@ -199,7 +199,7 @@ def validate_dataobj(inst: BaseDataset, attr: attrs.Attribute, value: Any) -> No
     exc:`TypeError`
         If the input cannot be converted to a float :obj:`~numpy.ndarray`.
     exc:`ValueError`
-        If the value is ``None``, or not 4-dimensional.
+        If the value is :obj:`None`, or not 4-dimensional.
     """
     if value is None:
         raise ValueError(DATAOBJ_ABSENCE_ERROR_MSG)
@@ -232,7 +232,7 @@ def validate_affine(inst: BaseDataset, attr: attrs.Attribute, value: Any) -> Non
     exc:`TypeError`
         If the input cannot be converted to a float :obj:`~numpy.ndarray`.
     exc:`ValueError`
-        If the value is ``None``, or not shaped ``(4, 4)``.
+        If the value is :obj:`None`, or not shaped ``(4, 4)``.
     """
     if value is None:
         raise ValueError(AFFINE_ABSENCE_ERROR_MSG)
@@ -343,8 +343,8 @@ class BaseDataset(Generic[Unpack[Ts]]):
             The selected data subset.
             If ``idx`` is a single integer, this will have shape ``(X, Y, Z)``,
             otherwise it may have shape ``(X, Y, Z, k)``.
-        affine : :obj:`~numpy.ndarray` or ``None``
-            The corresponding per-volume motion affine(s) or ``None`` if identity transform(s).
+        affine : :obj:`~numpy.ndarray` or :obj:`None`
+            The corresponding per-volume motion affine(s) or :obj:`None` if identity transform(s).
         Unpack[:obj:`~nifreeze.data.base.Ts`]
             Zero or more additional per-volume fields returned as unpacked
             trailing elements. The exact number, order, and types of elements
@@ -404,7 +404,7 @@ class BaseDataset(Generic[Unpack[Ts]]):
         ----------
         index : :obj:`int`
             The volume index to transform.
-        affine : :obj:`numpy.ndarray`
+        affine : :obj:`~numpy.ndarray`
             The 4x4 affine matrix to be applied.
 
         """
@@ -471,8 +471,8 @@ class BaseDataset(Generic[Unpack[Ts]]):
         filename : :obj:`os.pathlike`, optional
             The output NIfTI file path.
         write_hmxfms : :obj:`bool`, optional
-            If ``True``, the head motion affines will be written out to filesystem
-            with BIDS' X5 format.
+            If :obj:`True`, the head motion affines will be written out to
+            filesystem with BIDS' X5 format.
         order : :obj:`int`, optional
             The interpolation order to use when resampling the data.
             Defaults to 3 (cubic interpolation).
@@ -510,7 +510,7 @@ def to_nifti(
     filename : :obj:`os.pathlike`, optional
         The output NIfTI file path.
     write_hmxfms : :obj:`bool`, optional
-        If ``True``, the head motion affines will be written out to filesystem
+        If :obj:`True`, the head motion affines will be written out to filesystem
         with BIDS' X5 format.
     order : :obj:`int`, optional
         The interpolation order to use when resampling the data.

--- a/src/nifreeze/data/dmri/base.py
+++ b/src/nifreeze/data/dmri/base.py
@@ -294,7 +294,7 @@ class DWI(BaseDataset[np.ndarray]):
         compression : :obj:`str`, optional
             Compression strategy.
             See :obj:`~h5py.Group.create_dataset` documentation.
-        compression_opts : :obj:`typing.Any`, optional
+        compression_opts : :obj:`~typing.Any`, optional
             Parameters for compression
             `filters <https://docs.h5py.org/en/stable/high/dataset.html#dataset-compression>`__.
 

--- a/src/nifreeze/data/filtering.py
+++ b/src/nifreeze/data/filtering.py
@@ -70,15 +70,15 @@ def advanced_clip(
         The desired data type for the output array. Supported types are "uint8"
         and "int16".
     invert : :obj:`bool`, optional
-        If ``True``, inverts the intensity values after scaling (1.0 - ``data``).
+        If :obj:`True`, inverts the intensity values after scaling (1.0 - ``data``).
     inplace : :obj:`bool`, optional
-        If ``True``, the normalization is performed on the original data.
+        If :obj:`True`, the normalization is performed on the original data.
 
     Returns
     -------
-    :obj:`~numpy.ndarray` or None
+    :obj:`~numpy.ndarray` or :obj:`None`
         The clipped and scaled data array with the specified data type or
-        ``None`` if ``inplace`` is ``True``.
+        :obj:`None` if ``inplace`` is :obj:`True`.
 
     """
 
@@ -151,12 +151,12 @@ def robust_minmax_normalization(
     p_max : :obj:`float`, optional
         The upper percentile value for normalization.
     inplace : :obj:`bool`, optional
-        If ``False``, the normalization is performed on the original data.
+        If :obj:`False`, the normalization is performed on the original data.
 
     Returns
     -------
-    data : :obj:`~numpy.ndarray` or None
-        Normalized data or ``None`` if ``inplace`` is ``True``.
+    data : :obj:`~numpy.ndarray` or :obj:`None`
+        Normalized data or :obj:`None` if ``inplace`` is :obj:`True`.
     """
 
     normalized = data if inplace else data.copy()
@@ -197,12 +197,12 @@ def grand_mean_normalization(
     center : float, optional
         Central value around which to normalize the data.
     inplace : :obj:`bool`, optional
-        If ``False``, the normalization is performed on the original data.
+        If :obj:`False`, the normalization is performed on the original data.
 
     Returns
     -------
-    data : :obj:`~numpy.ndarray` or None
-        Normalized data or ``None`` if ``inplace`` is ``True``.
+    data : :obj:`~numpy.ndarray` or :obj:`None`
+        Normalized data or :obj:`None` if ``inplace`` is :obj:`True`.
     """
 
     normalized = data if inplace else data.copy()
@@ -234,7 +234,7 @@ def dwi_select_shells(
     Computes a boolean mask of the DWI shells around the given index with the
     provided lower and upper bound b-values.
 
-    If ``atol_low`` and ``atol_high`` are both ``None``, the returned shell mask
+    If ``atol_low`` and ``atol_high`` are both :obj:`None`, the returned shell mask
     corresponds to the lengths of the diffusion-sensitizing gradients.
 
     Parameters

--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -75,8 +75,8 @@ class PET(BaseDataset[np.ndarray]):
             The selected data subset.
             If ``idx`` is a single integer, this will have shape ``(X, Y, Z)``,
             otherwise it may have shape ``(X, Y, Z, k)``.
-        motion_affine : :obj:`~numpy.ndarray` or ``None``
-            The corresponding per-volume motion affine(s) or ``None`` if identity transform(s).
+        motion_affine : :obj:`~numpy.ndarray` or :obj:`None`
+            The corresponding per-volume motion affine(s) or :obj:`None` if identity transform(s).
         time : :obj:`~numpy.ndarray`
             The frame time corresponding to the index(es).
 
@@ -231,14 +231,14 @@ def from_nii(
     ----------
     filename : :obj:`os.pathlike`
         The NIfTI file.
-    frame_time : :obj:`numpy.ndarray` or :obj:`list` of :obj:`float`
+    frame_time : :obj:`~numpy.ndarray` or :obj:`list` of :obj:`float`
         The start times of each frame relative to the beginning of the acquisition.
     brainmask_file : :obj:`os.pathlike`, optional
         A brainmask NIfTI file. If provided, will be loaded and
         stored in the returned dataset.
-    frame_duration : :obj:`numpy.ndarray` or :obj:`list` of :obj:`float`, optional
+    frame_duration : :obj:`~numpy.ndarray` or :obj:`list` of :obj:`float`, optional
         The duration of each frame.
-        If ``None``, it is derived by the difference of consecutive frame times,
+        If :obj:`None`, it is derived by the difference of consecutive frame times,
         defaulting the last frame to match the second-last.
 
     Returns
@@ -320,8 +320,8 @@ def _compute_uptake_statistic(data: np.ndarray, stat_func: Callable = np.sum):
     data : :obj:`~numpy.ndarray`
         PET data.
     stat_func : :obj:`~collections.abc.Callable`, optional
-        Function to apply over voxels (e.g., :obj:`~numpy.sum`,
-        :obj:`~numpy.mean`, :obj:`~numpy.np.std`)
+        Function to apply over voxels (e.g., :func:`numpy.sum`,
+        :func:`numpy.mean`, :func:`numpy.std`)
 
     Returns
     -------

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -69,14 +69,14 @@ def gp_prediction(
         A fitted GaussianProcessRegressor model.
     gtab : :obj:`~dipy.core.gradients.GradientTable` or :obj:`~np.ndarray`
         Gradient table with one or more orientations at which the GP will be evaluated.
-    mask : :obj:`numpy.ndarray`, optional
+    mask : :obj:`~numpy.ndarray`, optional
         A boolean mask indicating which voxels to use (optional).
     return_std : bool, optional
         Whether to return the standard deviation of the predicted signal.
 
     Returns
     -------
-    :obj:`numpy.ndarray`
+    :obj:`~numpy.ndarray`
         A 3D or 4D array with the simulated gradient(s).
 
     """
@@ -221,7 +221,7 @@ class GaussianProcessModel(ReconstModel):
 
         Returns
         -------
-        :obj:`numpy.ndarray`
+        :obj:`~numpy.ndarray`
             A 3D or 4D array with the simulated gradient(s).
 
         """
@@ -240,7 +240,7 @@ class GPFit:
     model : :obj:`~sklearn.gaussian_process.GaussianProcessRegressor`
         The fitted Gaussian process regressor object.
     mask : :obj:`~numpy.ndarray`
-        The boolean mask used during fitting (can be ``None``).
+        The boolean mask used during fitting (can be :obj:`None`).
 
     """
 
@@ -277,7 +277,7 @@ class GPFit:
 
         Returns
         -------
-        :obj:`numpy.ndarray`
+        :obj:`~numpy.ndarray`
             A 3D or 4D array with the simulated gradient(s).
 
         """

--- a/src/nifreeze/model/base.py
+++ b/src/nifreeze/model/base.py
@@ -112,16 +112,16 @@ class BaseModel(ABC):
         """
         Fit and predict the indicated index of the dataset (abstract signature).
 
-        If ``index`` is ``None``, then the model is executed in *single-fit mode* meaning
+        If ``index`` is :obj:`None`, then the model is executed in *single-fit mode* meaning
         that it will be run only once in all the data available.
         Please note that all the predictions of this model will suffer from data leakage
         from the original volume.
 
         Parameters
         ----------
-        index : :obj:`int` or ``None``
+        index : :obj:`int`, optional
             The index to predict.
-            If ``None``, no prediction will be executed.
+            If :obj:`None`, no prediction will be executed.
 
         """
         return None

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -310,7 +310,7 @@ class ExponentialKriging(Kernel):
         eval_gradient : :obj:`bool`, optional
             Determines whether the gradient with respect to the log of
             the kernel hyperparameter is computed.
-            Only supported when Y is ``None``.
+            Only supported when Y is :obj:`None`.
 
         Returns
         -------
@@ -321,7 +321,7 @@ class ExponentialKriging(Kernel):
                 optional
             The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
-            is True.
+            is :obj:`True`.
 
         """
         thetas = compute_pairwise_angles(X, Y)
@@ -415,7 +415,7 @@ class SphericalKriging(Kernel):
         eval_gradient : :obj:`bool`, optional
             Determines whether the gradient with respect to the log of
             the kernel hyperparameter is computed.
-            Only supported when Y is ``None``.
+            Only supported when Y is :obj:`None`.
 
         Returns
         -------
@@ -426,7 +426,7 @@ class SphericalKriging(Kernel):
                 optional
             The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when ``eval_gradient``
-            is True.
+            is :obj:`True`.
 
         """
         thetas = compute_pairwise_angles(X, Y)
@@ -558,7 +558,7 @@ def compute_pairwise_angles(
     r"""Compute pairwise angles across diffusion gradient encoding directions.
 
     Following :footcite:p:`andersson_non-parametric_2015`:, it computes the smallest of the angles between
-    each pair if ``closest_polarity`` is ``True``, i.e.,
+    each pair if ``closest_polarity`` is :obj:`True`, i.e.,
 
     .. math::
 
@@ -569,14 +569,14 @@ def compute_pairwise_angles(
     X : {array-like, sparse matrix} of shape (n_samples_X, n_features)
         Input data.
     Y : {array-like, sparse matrix} of shape (n_samples_Y, n_features), optional
-        Input data. If ``None``, the output will be the pairwise
+        Input data. If :obj:`None`, the output will be the pairwise
         similarities between all samples in ``X``.
     dense_output : :obj:`bool`, optional
         Whether to return dense output even when the input is sparse. If
-        ``False``, the output is sparse if both input arrays are sparse.
+        :obj:`False`, the output is sparse if both input arrays are sparse.
     closest_polarity : :obj:`bool`, optional
-        ``True`` to consider the smallest of the two angles between the crossing
-         lines resulting from reversing each vector pair.
+        :obj:`True` to consider the smallest of the two angles between the
+        crossing lines resulting from reversing each vector pair.
 
     Returns
     -------

--- a/src/nifreeze/registration/ants.py
+++ b/src/nifreeze/registration/ants.py
@@ -114,15 +114,17 @@ def _prepare_registration_data(
         Current volume for which a transformation is to be estimated.
     predicted : :obj:`~numpy.ndarray`
         Predicted volume's data array (that is, spatial reference).
-    affine : :obj:`numpy.ndarray`
+    affine : :obj:`~numpy.ndarray`
         Orientation affine from the original NIfTI.
     vol_idx : :obj:`int`
         Volume index.
     dirname : :obj:`os.pathlike`
         Directory name where the data is saved.
-    clip : :obj:`str` or ``None``
+    clip : :obj:`str`, optional
         Clip intensity of ``"sample"``, ``"predicted"``, ``"both"``,
         or ``"none"`` of the images.
+    init_affine : :obj:`~numpy.ndarray`, optional
+        Initial affine transform.
 
     Returns
     -------
@@ -130,7 +132,7 @@ def _prepare_registration_data(
         Predicted image filename.
     sample_path : :obj:`~pathlib.Path`
         Current volume's filename.
-    init_path : :obj:`~pathlib.Path` or ``None``
+    init_path : :obj:`~pathlib.Path` or :obj:`None`
         An initialization affine (for second and further estimators).
 
     """

--- a/src/nifreeze/registration/utils.py
+++ b/src/nifreeze/registration/utils.py
@@ -59,7 +59,7 @@ def displacements_within_mask(
         The transformation to test. This transformation is applied to the
         voxel coordinates.
     reference_xfm : :obj:`~nitransforms.base.TransformBase`, optional
-        A reference transformation to compare with. If ``None``, the identity
+        A reference transformation to compare with. If :obj:`None`, the identity
         transformation is assumed (no transformation).
 
     Returns
@@ -126,14 +126,14 @@ def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = RADIUS
 
     Parameters
     ----------
-    motion_parameters : :obj:`numpy.ndarray`
+    motion_parameters : :obj:`~numpy.ndarray`
         Motion parameters.
     radius : :obj:`float`, optional
         Radius (in mm) of a sphere mimicking the size of a typical human brain.
 
     Returns
     -------
-    :obj:`numpy.ndarray`
+    :obj:`~numpy.ndarray`
         The framewise displacement (FD) as the sum of absolute differences
         between consecutive frames.
     """

--- a/src/nifreeze/testing/simulations.py
+++ b/src/nifreeze/testing/simulations.py
@@ -422,7 +422,7 @@ def serialize_dwi(dwi_data, dwi_data_fname, affine: np.ndarray | None = None):
     dwi_data_fname : :obj:`str`
         Filename of NIfTI file to save the DWI signal.
     affine : :obj:`~numpy.ndarray`, optional
-        Affine matrix. If ``None`` an identity affine matrix is used.
+        Affine matrix. If :obj:`None` an identity affine matrix is used.
     """
 
     if affine is None:
@@ -475,7 +475,7 @@ def serialize_dmri(
     bvec_data_fname : :obj:`str`
         Filename of NIfTI file to save the diffusion-encoding gradient b-vecs.
     affine : :obj:`~numpy.ndarray`, optional
-        Affine matrix. If ``None`` an identity affine matrix is used.
+        Affine matrix. If :obj:`None` an identity affine matrix is used.
     """
 
     serialize_dwi(dwi_data, dwi_data_fname, affine=affine)

--- a/src/nifreeze/utils/iterators.py
+++ b/src/nifreeze/utils/iterators.py
@@ -36,7 +36,7 @@ correspond to properties that distinguish one imaging modality from another, and
 are part of the 4th axis (e.g. diffusion gradients in DWI or update in PET)."""
 
 SIZE_KEYS_DOC = """
-size : obj:`int`, optional
+size : :obj:`int`, optional
     Size of the structure to iterate over.
 bvals : :obj:`list`, optional
     List of b-values corresponding to all orientations of a DWI dataset.
@@ -131,15 +131,15 @@ Traverse the dataset volumes randomly.
 
 If the ``seed`` key is present in the keyword arguments, initializes the seed
 of Python's ``random`` pseudo-random number generator library with the given
-value. Specifically, if ``False``, ``None`` is used as the seed; if ``True``, a
-default seed value is used.
+value. Specifically, if :obj:`False`, :obj:`None` is used as the seed;
+if :obj:`True`, a default seed value is used.
 
 Other Parameters
 ----------------
-seed : :obj:`int`, :obj:`bool`, :obj:`str`, or ``None``
-    If :obj:`int` or :obj:`str` or ``None``, initializes the seed of Python's random generator
-    with the given value. If ``False``, the random generator is passed ``None``.
-    If ``True``, a default seed value is set.
+seed : :obj:`int`, :obj:`bool`, :obj:`str`, or :obj:`None`
+    If :obj:`int` or :obj:`str` or :obj:`None`, initializes the seed of Python's
+    random generator with the given value. If :obj:`False`, the random generator
+    is passed :obj:`None`. If :obj:`True`, a default seed value is set.
 
 {SIZE_KEYS_DOC}
 
@@ -182,7 +182,7 @@ def _value_iterator(
     values : :obj:`Sequence`
         List of values to traverse.
     ascending : :obj:`bool`
-        If ``True``, traverse in ascending order; traverse in descending order
+        If :obj:`True`, traverse in ascending order; traverse in descending order
         otherwise.
     round_decimals : :obj:`int`, optional
         Number of decimals to round values for sorting.

--- a/src/nifreeze/viz/bland_altman.py
+++ b/src/nifreeze/viz/bland_altman.py
@@ -26,6 +26,7 @@ import enum
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.figure import Figure
 
 from nifreeze.analysis.measure_agreement import (
     BASalientEntity,
@@ -46,7 +47,7 @@ def plot_bland_altman(
     ci: float = 0.95,
     salient_data: dict | None = None,
     figsize: tuple | None = (15, 10),
-) -> plt.Figure:
+) -> Figure:
     """Create a Bland-Altman plot.
 
     Create a Bland-Altman plot :footcite:p:`bland_statistical_1986` and
@@ -54,9 +55,9 @@ def plot_bland_altman(
 
     Parameters
     ----------
-    data1 : :obj:`numpy.ndarray`
+    data1 : :obj:`~numpy.ndarray`
         Data values.
-    data2 : :obj:`numpy.ndarray`
+    data2 : :obj:`~numpy.ndarray`
         Data values.
     ci : :obj:`float`, optional
         Confidence interval value. Must be in the [0, 1] range.
@@ -70,7 +71,7 @@ def plot_bland_altman(
 
     Returns
     -------
-    fig : :obj:`matplotlib.pyplot.Figure`
+    fig : :obj:`~matplotlib.figure.Figure`
         Matplotlib figure.
 
     References

--- a/src/nifreeze/viz/motion_viz.py
+++ b/src/nifreeze/viz/motion_viz.py
@@ -80,18 +80,18 @@ def plot_framewise_displacement(
 
     Parameters
     ----------
-    fd : :obj:`~pd.DataFrame`
+    fd : :obj:`~pandas.DataFrame`
         Framewise displacement values.
     labels : :obj:`list`
         Labels for legend.
     cmap_name : :obj:`str`, optional
         Colormap name.
-    ax : :obj:`Axes`, optional
+    ax : :obj:`~matplotlib.axes.Axes`, optional
         Figure axes.
 
     Returns
     -------
-    ax : :obj:`Axes`
+    ax : :obj:`~matplotlib.axes.Axes`
         Figure plot axis.
     """
 
@@ -201,13 +201,13 @@ def plot_motion_overlay(
     slice_idx : :obj:`int`
         Slice index to plot.
     smooth : :obj:`bool`, optional
-        ``True`` to smooth the motion relative difference.
-    ax : :obj:`Axes`, optional
+        :obj:`True` to smooth the motion relative difference.
+    ax : :obj:`~matplotlib.axes.Axes`, optional
         Figure axis.
 
     Returns
     -------
-    ax : :obj:`Axes`
+    ax : :obj:`~matplotlib.axes.Axes`
         Figure plot axis.
     """
 

--- a/src/nifreeze/viz/signals.py
+++ b/src/nifreeze/viz/signals.py
@@ -25,6 +25,7 @@
 import matplotlib.gridspec as gridspec
 import numpy as np
 from matplotlib import pyplot as plt
+from matplotlib.figure import Figure
 from scipy.spatial import ConvexHull, KDTree
 from scipy.stats import pearsonr
 
@@ -38,7 +39,7 @@ def plot_error(
     title: str,
     color: str = "orange",
     figsize: tuple[float, float] = (19.2, 10.8),
-) -> plt.Figure:
+) -> Figure:
     """
     Plot the error and standard deviation.
 
@@ -63,7 +64,7 @@ def plot_error(
 
     Returns
     -------
-    :obj:`~matplotlib.pyplot.Figure`
+    :obj:`~matplotlib.figure.Figure`
         Matplotlib figure object.
 
     """


### PR DESCRIPTION
Improve documentation quality:
- Remove spare backtick when linkiing the `BASalientEntity` enum class.
- Use :obj:`None`, :obj:`True`, and obj:`None` to link their appearances to the corresponding Python constants.
- Add the tilde to various types to shorten the displayed link to the last component. Increases consistency across the documentation.
- Use the appropriate roles to document NumPy functions: e.g. `:func:`numpy.sum`` instead of `:obj:`~numpy.sum``.
- Prefer using `optional` for documenting optional parameters instead of explicitly documenting them as `... or `None``: documenting that they can be `None` should be the job of the type annotation, and it reduces maintenance burden.
- Add missing parametr docstring to `_prepare_registration_data`.
- Add missing leading colon to `obj` role when documenting `utils.iterators.SIZE_KEYS_DOC`.
- Use the fully qualified names to link pandas and matplotlib objects: e.g. use :obj:`pandas.DataFrame` instead of :obj:`pd.DataFrame`, or :obj:`~matplotlib.axes.Axes` instead of :obj:`Axes`. The aliases are not listed in the pandas inventory file of pandas and thus, do not get resolved. Similarly, even if `Axes` is imported from `matplotlib` the inventory file contains the fully qualified name, and thus, the `Axes` name cannot be resolved.
- Import `Figure` from `matplotlib.figure` so that the function
  signature return type gets annotated. Even if Sphinx can resolve
   forward references (i.e. string annotations: e.g. "matplotlib.figure.Figure") in return type annotations to try to benefit from PEP 563 (postponed evaluation of annotations), the type checker complains. So, in order to avoid importing `matplotlib` at runtime (e.g. expensive, optional dependency, etc.), import the required symbol only, in line with the fact that `Axes` is imported where required.
- Fix a matplotlib `Figure` type annotation: `Figure` dwells in the `figure` module, not `pyplot`.
- Fix the indentation of the parameters in the `_has_dim_size` function docstring.
- Add the `attrs` entry to the `intersphinx_mapping` mapping so that the corresponding symbols can be linked.