### PR TITLE
ENH: Do not write gradients back if not necessary

### DIFF
--- a/test/test_data_dmri.py
+++ b/test/test_data_dmri.py
@@ -849,17 +849,18 @@ def test_to_nifti(
         np.allclose(_nii_dataobj.affine, _nii_load.affine)
 
         # Check gradients
-        bvecs_file = _filename.with_suffix("").with_suffix(".bvec")
-        bvals_file = _filename.with_suffix("").with_suffix(".bval")
-        assert bvals_file.is_file()
-        assert bvecs_file.is_file()
+        if motion_affines is not None:
+            bvecs_file = _filename.with_suffix("").with_suffix(".bvec")
+            bvals_file = _filename.with_suffix("").with_suffix(".bval")
+            assert bvals_file.is_file()
+            assert bvecs_file.is_file()
 
-        # Read the files
-        bvals_from_file = np.loadtxt(bvals_file)
-        bvecs_from_file = np.loadtxt(bvecs_file).T
+            # Read the files
+            bvals_from_file = np.loadtxt(bvals_file)
+            bvecs_from_file = np.loadtxt(bvecs_file).T
 
-        assert np.allclose(bvals_from_file, bvals_dwi, rtol=0, atol=10**-bvals_dec_places)
-        assert np.allclose(bvecs_from_file, bvecs_dwi, rtol=0, atol=10**-bvecs_dec_places)
+            assert np.allclose(bvals_from_file, bvals_dwi, rtol=0, atol=10**-bvals_dec_places)
+            assert np.allclose(bvecs_from_file, bvecs_dwi, rtol=0, atol=10**-bvecs_dec_places)
 
 
 @pytest.mark.skip(reason="to_nifti takes absurdly long")

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -74,12 +74,14 @@ def test_run_call(tmp_path, monkeypatch, write_hdf5):
             cli_run.main(argv)
 
     assert Path(tmp_path / out_filename).is_file()
-    out_bval_filename = Path(Path(input_file).name).stem + ".bval"
-    out_bval_path: Path = Path(tmp_path) / out_bval_filename
-    out_bvec_filename = Path(Path(input_file).name).stem + ".bvec"
-    out_bvec_path: Path = Path(tmp_path) / out_bvec_filename
-    assert out_bval_path.is_file()
-    assert out_bvec_path.is_file()
+    if called["dataset"].motion_affines is not None:
+        assert Path(tmp_path / out_filename).is_file()
+        out_bval_filename = Path(Path(input_file).name).stem + ".bval"
+        out_bval_path: Path = Path(tmp_path) / out_bval_filename
+        out_bvec_filename = Path(Path(input_file).name).stem + ".bvec"
+        out_bvec_path: Path = Path(tmp_path) / out_bvec_filename
+        assert out_bval_path.is_file()
+        assert out_bvec_path.is_file()
     if write_hdf5:
         out_h5_filename = Path(Path(input_file).name).stem + ".h5"
         out_h5_path: Path = Path(tmp_path) / out_h5_filename


### PR DESCRIPTION
Do not write gradients back if not necessary: if no motion affine data exists, gradient vectors do not need to be rotated, and thus the primary gradient data is still valid. This patch set conditionally writes gradients on the motion affine data.