### PR TITLE
ENH: Freeze data class attributes

### DIFF
--- a/src/nifreeze/data/dmri/base.py
+++ b/src/nifreeze/data/dmri/base.py
@@ -128,10 +128,14 @@ class DWI(BaseDataset[np.ndarray]):
         eq=attrs.cmp_using(eq=_cmp),
         converter=format_gradients,
         validator=validate_gradients,
+        on_setattr=attrs.setters.frozen,
     )
     """A 2D numpy array of the gradient table (``N`` orientations x ``C`` components)."""
     bzero: np.ndarray | None = attrs.field(
-        default=None, repr=_data_repr, eq=attrs.cmp_using(eq=_cmp)
+        default=None,
+        repr=_data_repr,
+        eq=attrs.cmp_using(eq=_cmp),
+        on_setattr=attrs.setters.frozen,
     )
     """A *b=0* reference map, computed automatically when low-b frames are present."""
     eddy_xfms: list = attrs.field(default=None)

--- a/src/nifreeze/data/pet.py
+++ b/src/nifreeze/data/pet.py
@@ -217,6 +217,7 @@ class PET(BaseDataset[np.ndarray]):
         eq=attrs.cmp_using(eq=_cmp),
         converter=attrs.Converter(format_array_like, takes_field=True),  # type: ignore
         validator=validate_1d_array,
+        on_setattr=attrs.setters.frozen,
     )
     """A (N,) numpy array specifying the midpoint timing of each sample or frame."""
     total_duration: float = attrs.field(
@@ -224,6 +225,7 @@ class PET(BaseDataset[np.ndarray]):
         repr=True,
         converter=attrs.Converter(format_scalar_like, takes_field=True),  # type: ignore
         validator=attrs.validators.optional(attrs.validators.instance_of(float)),
+        on_setattr=attrs.setters.frozen,
     )
     """A float representing the total duration of the dataset."""
 


### PR DESCRIPTION
Freeze data class attributes: disallow assignments once the data class instance has been created. Attributes (e.g. dMRI gradients, PET temporal data, etc.) do not change along the prediction process, so freezing them disallows introducing inadvertent inconsistencies in the attribute values.