### PR TITLE
REF: Refactor `nifreeze.data.pet.py` into an own module

### DIFF
--- a/src/nifreeze/data/pet/__init__.py
+++ b/src/nifreeze/data/pet/__init__.py
@@ -1,0 +1,46 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""
+PET data representation
+------------------------
+This submodule implements data structures and I/O utilities for PET data.
+
+**Data Representation**.
+The :class:`~nifreeze.data.pet.base.PET` class requires a ``dataobj`` that can
+be an array-like object.
+The class instantiation requires :attr:`~nifreeze.data.pet.base.PET.midframe`
+and :attr:`~nifreeze.data.pet.base.PET.total_duration` value data to be
+provided.
+Both these values are computed from the frame start time (``FrameTimesStart`` in
+BIDS terms).
+The :meth:`~nifreeze.data.pet.io.from_nii` function takes a temporal file
+parameter, which is expected to be a JSON file containing the frame start time.
+Ultimately, the midframe and total duration values are computed by the
+:meth:`~nifreeze.data.pet.utils.compute_temporal_markers` method.
+
+"""
+
+from nifreeze.data.pet.base import PET
+from nifreeze.data.pet.io import from_nii
+
+__all__ = ["PET", "from_nii"]

--- a/src/nifreeze/data/pet/base.py
+++ b/src/nifreeze/data/pet/base.py
@@ -24,23 +24,19 @@
 
 from __future__ import annotations
 
-import json
 from collections import namedtuple
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 
 import attrs
 import h5py
 import nibabel as nb
 import numpy as np
-from nibabel.spatialimages import SpatialImage
 from nitransforms.linear import Affine
 from nitransforms.resampling import apply
 from typing_extensions import Self
 
 from nifreeze.data.base import BaseDataset, _cmp, _data_repr, _has_ndim
-from nifreeze.utils.ndimage import get_data, load_api
 
 ATTRIBUTE_ABSENCE_ERROR_MSG = "PET '{attribute}' may not be None"
 """PET initialization array attribute absence error message."""
@@ -67,12 +63,6 @@ SCALAR_ATTRIBUTE_ERROR_MSG = (
     "PET '{attribute}' must be a numeric or single-element sequence object."
 )
 """PET initialization scalar attribute object error message."""
-
-TEMPORAL_FILE_KEY_ERROR_MSG = "{key} key not found in temporal file"
-"""PET temporal file key error message."""
-
-FRAME_TIME_START_KEY = "FrameTimesStart"
-"""PET frame time start key."""
 
 
 def format_scalar_like(value: Any, attr: attrs.Attribute) -> float:
@@ -389,156 +379,3 @@ class PET(BaseDataset[np.ndarray]):
             root = in_file["/0"]
             data = {k: np.asanyarray(v) for k, v in root.items() if not k.startswith("_")}
         return cls(**data)
-
-
-def from_nii(
-    filename: Path | str,
-    temporal_file: Path | str,
-    brainmask_file: Path | str | None = None,
-) -> PET:
-    """
-    Load PET data from NIfTI, creating a PET object with appropriate metadata.
-
-    Parameters
-    ----------
-    filename : :obj:`os.pathlike`
-        The NIfTI file.
-    temporal_file : :obj:`os.pathlike`
-        A JSON file containing temporal data. It must at least contain
-        ``FrameTimesStart`` data.
-    brainmask_file : :obj:`os.pathlike`, optional
-        A brainmask NIfTI file. If provided, will be loaded and
-        stored in the returned dataset.
-
-    Returns
-    -------
-    :obj:`~nifreeze.data.pet.PET`
-        A PET object storing the data, metadata, and any optional mask.
-
-    Raises
-    ------
-    :exc:`RuntimeError`
-        If ``FrameTimesStart`` is not provided (BIDS requires it).
-
-    """
-
-    filename = Path(filename)
-
-    # 1) Load a NIfTI
-    img = load_api(filename, SpatialImage)
-    fulldata = get_data(img)
-
-    # 2) Load the temporal data
-    with open(temporal_file, "r") as f:
-        temporal_attrs = json.load(f)
-
-    frame_time = temporal_attrs.get(FRAME_TIME_START_KEY, None)
-    if frame_time is None:
-        raise RuntimeError(TEMPORAL_FILE_KEY_ERROR_MSG.format(key=FRAME_TIME_START_KEY))
-
-    # 3) If a brainmask_file was provided, load it
-    brainmask_data = None
-    if brainmask_file is not None:
-        mask_img = load_api(brainmask_file, SpatialImage)
-        brainmask_data = np.asanyarray(mask_img.dataobj, dtype=bool)
-
-    # 4) Compute temporal attributes
-    midframe, total_duration = _compute_temporal_markers(np.asarray(frame_time))
-
-    # 5) Create and return the PET instance
-    return PET(
-        dataobj=fulldata,
-        affine=img.affine,
-        brainmask=brainmask_data,
-        midframe=midframe,
-        total_duration=total_duration,
-    )
-
-
-def _compute_temporal_markers(frame_time: np.ndarray) -> Tuple[np.ndarray, float]:
-    """Compute the frame temporal markers from the frame time values.
-
-    Computes the midframe times and the total duration following the principles
-    detailed below.
-
-    Let :math:`K` be the number of frames and :math:`t_{k}` be the :math:`k`-th
-    (start) frame time. For each frame :math:`k`, the frame duration
-    :math:`d_{k}` is defined as the difference between consecutive frame times:
-
-    .. math::
-       d_{k} = t_{k+1} - t_{k}
-
-    If necessary, the last frame duration is set to the value of the second to
-    last frame to match the appropriate dimensionality in this implementation.
-
-    Per-frame midpoints :math:`m_{k}` are computed as:
-
-    .. math::
-       m_{k} = t_{k} + \\frac{d_k}{2}
-
-    The total duration :math:`D` of the acquisition is a scalar computed as the
-    sum of the frame durations:
-
-    .. math::
-       D = \\sum_{k=1}^{K} d_{k}
-
-    or, equivalently, the difference between the last frame start and its
-    duration once the frame times have been time-origin shifted:
-
-    .. math::
-       D = t_{K} - d_{K}
-
-    Frame times are time-origin shifted (i.e. the earliest time is zeroed out)
-    if not already done at the beginning of the process for the sake of
-    simplicity.
-
-    Parameters
-    ----------
-    frame_time : :obj:`~numpy.ndarray`
-        Frame time values.
-
-    Returns
-    -------
-    :obj:`tuple`
-        Midpoint timing of each frame and total duration
-    """
-
-    # Time-origin shift: zero out the earliest time if necessary
-    # Flatten the array in case it is not a 1D array
-    if not np.isclose(frame_time.ravel()[0], 0):
-        frame_time -= frame_time.flat[0]
-
-    # If shape is e.g. (N,), then we can do
-    frame_duration = np.diff(frame_time)
-    if len(frame_duration) == (len(frame_time) - 1):
-        frame_duration = np.append(
-            frame_duration, frame_duration[-1]
-        )  # last frame same as second-last
-
-    midframe = frame_time + frame_duration / 2
-    total_duration = float(frame_time[-1] + frame_duration[-1])
-
-    return midframe, total_duration
-
-
-def compute_uptake_statistic(data: np.ndarray, stat_func: Callable[..., np.ndarray] = np.sum):
-    """Compute a statistic over all voxels for each frame on a PET sequence.
-
-    Assumes the last dimension corresponds to the number of frames in the
-    sequence.
-
-    Parameters
-    ----------
-    data : :obj:`~numpy.ndarray`
-        PET data.
-    stat_func : :obj:`~collections.abc.Callable`, optional
-        Function to apply over voxels (e.g., :func:`numpy.sum`,
-        :func:`numpy.mean`, :func:`numpy.std`)
-
-    Returns
-    -------
-    :obj:`~numpy.ndarray`
-        1D array of statistic values for each frame.
-    """
-
-    return stat_func(data.reshape(-1, data.shape[-1]), axis=0)

--- a/src/nifreeze/data/pet/io.py
+++ b/src/nifreeze/data/pet/io.py
@@ -1,0 +1,103 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""Input/Output utilities for PET objects."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+from nibabel.spatialimages import SpatialImage
+
+from nifreeze.data.pet.base import PET
+from nifreeze.data.pet.utils import compute_temporal_markers
+from nifreeze.utils.ndimage import get_data, load_api
+
+TEMPORAL_FILE_KEY_ERROR_MSG = "{key} key not found in temporal file"
+"""PET temporal file key error message."""
+
+FRAME_TIME_START_KEY = "FrameTimesStart"
+"""PET frame time start key."""
+
+
+def from_nii(
+    filename: Path | str,
+    temporal_file: Path | str,
+    brainmask_file: Path | str | None = None,
+) -> PET:
+    """
+    Load PET data from NIfTI, creating a PET object with appropriate metadata.
+
+    Parameters
+    ----------
+    filename : :obj:`os.pathlike`
+        The NIfTI file.
+    temporal_file : :obj:`os.pathlike`
+        A JSON file containing temporal data. It must at least contain
+        ``FrameTimesStart`` data.
+    brainmask_file : :obj:`os.pathlike`, optional
+        A brainmask NIfTI file. If provided, will be loaded and
+        stored in the returned dataset.
+
+    Returns
+    -------
+    :obj:`~nifreeze.data.pet.PET`
+        A PET object storing the data, metadata, and any optional mask.
+
+    Raises
+    ------
+    :exc:`RuntimeError`
+        If ``FrameTimesStart`` is not provided (BIDS requires it).
+
+    """
+
+    filename = Path(filename)
+
+    # 1) Load a NIfTI
+    img = load_api(filename, SpatialImage)
+    fulldata = get_data(img)
+
+    # 2) Load the temporal data
+    with open(temporal_file, "r") as f:
+        temporal_attrs = json.load(f)
+
+    frame_time = temporal_attrs.get(FRAME_TIME_START_KEY, None)
+    if frame_time is None:
+        raise RuntimeError(TEMPORAL_FILE_KEY_ERROR_MSG.format(key=FRAME_TIME_START_KEY))
+
+    # 3) If a brainmask_file was provided, load it
+    brainmask_data = None
+    if brainmask_file is not None:
+        mask_img = load_api(brainmask_file, SpatialImage)
+        brainmask_data = np.asanyarray(mask_img.dataobj, dtype=bool)
+
+    # 4) Compute temporal attributes
+    midframe, total_duration = compute_temporal_markers(np.asarray(frame_time))
+
+    # 5) Create and return the PET instance
+    return PET(
+        dataobj=fulldata,
+        affine=img.affine,
+        brainmask=brainmask_data,
+        midframe=midframe,
+        total_duration=total_duration,
+    )

--- a/src/nifreeze/data/pet/utils.py
+++ b/src/nifreeze/data/pet/utils.py
@@ -1,0 +1,117 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""Utilities for handling PET temporal and activity attributes."""
+
+from collections.abc import Callable
+from typing import Tuple
+
+import numpy as np
+
+
+def compute_temporal_markers(frame_time: np.ndarray) -> Tuple[np.ndarray, float]:
+    """Compute the frame temporal markers from the frame time values.
+
+    Computes the midframe times and the total duration following the principles
+    detailed below.
+
+    Let :math:`K` be the number of frames and :math:`t_{k}` be the :math:`k`-th
+    (start) frame time. For each frame :math:`k`, the frame duration
+    :math:`d_{k}` is defined as the difference between consecutive frame times:
+
+    .. math::
+       d_{k} = t_{k+1} - t_{k}
+
+    If necessary, the last frame duration is set to the value of the second to
+    last frame to match the appropriate dimensionality in this implementation.
+
+    Per-frame midpoints :math:`m_{k}` are computed as:
+
+    .. math::
+       m_{k} = t_{k} + \\frac{d_k}{2}
+
+    The total duration :math:`D` of the acquisition is a scalar computed as the
+    sum of the frame durations:
+
+    .. math::
+       D = \\sum_{k=1}^{K} d_{k}
+
+    or, equivalently, the difference between the last frame start and its
+    duration once the frame times have been time-origin shifted:
+
+    .. math::
+       D = t_{K} - d_{K}
+
+    Frame times are time-origin shifted (i.e. the earliest time is zeroed out)
+    if not already done at the beginning of the process for the sake of
+    simplicity.
+
+    Parameters
+    ----------
+    frame_time : :obj:`~numpy.ndarray`
+        Frame time values.
+
+    Returns
+    -------
+    :obj:`tuple`
+        Midpoint timing of each frame and total duration
+    """
+
+    # Time-origin shift: zero out the earliest time if necessary
+    # Flatten the array in case it is not a 1D array
+    if not np.isclose(frame_time.ravel()[0], 0):
+        frame_time -= frame_time.flat[0]
+
+    # If shape is e.g. (N,), then we can do
+    frame_duration = np.diff(frame_time)
+    if len(frame_duration) == (len(frame_time) - 1):
+        frame_duration = np.append(
+            frame_duration, frame_duration[-1]
+        )  # last frame same as second-last
+
+    midframe = frame_time + frame_duration / 2
+    total_duration = float(frame_time[-1] + frame_duration[-1])
+
+    return midframe, total_duration
+
+
+def compute_uptake_statistic(data: np.ndarray, stat_func: Callable[..., np.ndarray] = np.sum):
+    """Compute a statistic over all voxels for each frame on a PET sequence.
+
+    Assumes the last dimension corresponds to the number of frames in the
+    sequence.
+
+    Parameters
+    ----------
+    data : :obj:`~numpy.ndarray`
+        PET data.
+    stat_func : :obj:`~collections.abc.Callable`, optional
+        Function to apply over voxels (e.g., :func:`numpy.sum`,
+        :func:`numpy.mean`, :func:`numpy.std`)
+
+    Returns
+    -------
+    :obj:`~numpy.ndarray`
+        1D array of statistic values for each frame.
+    """
+
+    return stat_func(data.reshape(-1, data.shape[-1]), axis=0)

--- a/test/test_data_pet.py
+++ b/test/test_data_pet.py
@@ -33,23 +33,20 @@ import pytest
 from nitransforms.linear import Affine
 
 from nifreeze.data import load as nifreeze_load
-from nifreeze.data.pet import (
+from nifreeze.data.pet.base import (
     ARRAY_ATTRIBUTE_NDIM_ERROR_MSG,
     ARRAY_ATTRIBUTE_OBJECT_ERROR_MSG,
     ATTRIBUTE_ABSENCE_ERROR_MSG,
     ATTRIBUTE_VOLUME_DIMENSIONALITY_MISMATCH_ERROR_MSG,
-    FRAME_TIME_START_KEY,
     PET,
     SCALAR_ATTRIBUTE_ERROR_MSG,
     TEMPORAL_ATTRIBUTE_INCONSISTENCY_ERROR_MSG,
-    TEMPORAL_FILE_KEY_ERROR_MSG,
-    _compute_temporal_markers,
-    compute_uptake_statistic,
     format_array_like,
     format_scalar_like,
-    from_nii,
     validate_1d_array,
 )
+from nifreeze.data.pet.io import FRAME_TIME_START_KEY, TEMPORAL_FILE_KEY_ERROR_MSG, from_nii
+from nifreeze.data.pet.utils import compute_temporal_markers, compute_uptake_statistic
 from nifreeze.utils.ndimage import load_api
 
 
@@ -369,7 +366,7 @@ def test_pet_instantiation_attribute_inconsistency_error(
 def test_compute_temporal_markers(frame_time, expected_midframe, expected_total_duration):
     frame_time = np.array(frame_time)
     expected_midframe = np.array(expected_midframe)
-    midframe, total_duration = _compute_temporal_markers(frame_time)
+    midframe, total_duration = compute_temporal_markers(frame_time)
     np.testing.assert_allclose(midframe, expected_midframe)
     assert np.isclose(total_duration, expected_total_duration)
 

--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -29,7 +29,7 @@ import pytest
 import nifreeze.estimator
 from nifreeze.data.base import BaseDataset
 from nifreeze.data.dmri.utils import DEFAULT_LOWB_THRESHOLD
-from nifreeze.data.pet import compute_uptake_statistic
+from nifreeze.data.pet.utils import compute_uptake_statistic
 from nifreeze.estimator import Estimator
 from nifreeze.model.base import BaseModel
 from nifreeze.utils import iterators


### PR DESCRIPTION
Refactor `nifreeze.data.pet.py` into an own module:
- Improves encapsulation and logic.
- Reduces the complexity of the former `nifreeze.data.pet.py` module as functions are now spread across different modules with better limited purpose.
- Increases consistency with the approach adopted for the DWI data module.

Add a description of the module.