### PR TITLE
STY: Make PET model error message variable names less verbose

### DIFF
--- a/src/nifreeze/model/pet.py
+++ b/src/nifreeze/model/pet.py
@@ -35,15 +35,15 @@ from scipy.sparse.linalg import cg
 from nifreeze.data.pet import PET
 from nifreeze.model.base import BaseModel
 
-PET_MODEL_PARAMETERS_ERROR_MSG = """\
+TIMEPOINT_XLIM_DATA_MISSING_ERROR_MSG = """\
 'timepoints' and 'xlim' must be specified, found: {timepoints} and {xlim}."""
 """PET model underspecification error."""
 
-PET_MODEL_TIMEPOINT_VALUE_ERROR_MSG = """\
+FIRST_TIMEPOINT_VALUE_ERROR_MSG = """\
 First frame 'timepoint' should not be zero or negative, found: {timepoints}."""
 """PET model timepoint value error message."""
 
-PET_MODEL_PARAMETER_CONSISTENCY_ERROR_MSG = """\
+LAST_TIMEPOINT_CONSISTENCY_ERROR_MSG = """\
 Last frame 'timepoints' value should not be equal or greater than 'xlim' \
 duration, found: {timepoints} and {xlim}."""
 """PET model parameter consistency error message."""
@@ -98,15 +98,15 @@ class PETModel(BaseModel):
 
         if timepoints is None or xlim is None:
             raise ValueError(
-                PET_MODEL_PARAMETERS_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
+                TIMEPOINT_XLIM_DATA_MISSING_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
             )
 
         if timepoints[0] < DEFAULT_TIMEPOINT_TOL:
-            raise ValueError(PET_MODEL_TIMEPOINT_VALUE_ERROR_MSG.format(timepoints=timepoints[0]))
+            raise ValueError(FIRST_TIMEPOINT_VALUE_ERROR_MSG.format(timepoints=timepoints[0]))
 
         if timepoints[-1] > xlim - DEFAULT_TIMEPOINT_TOL:
             raise ValueError(
-                PET_MODEL_PARAMETER_CONSISTENCY_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
+                LAST_TIMEPOINT_CONSISTENCY_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
             )
 
         self._order = order

--- a/test/test_model_pet.py
+++ b/test/test_model_pet.py
@@ -30,9 +30,9 @@ import pytest
 from nifreeze.data.pet import PET
 from nifreeze.model.pet import (
     DEFAULT_TIMEPOINT_TOL,
-    PET_MODEL_PARAMETER_CONSISTENCY_ERROR_MSG,
-    PET_MODEL_PARAMETERS_ERROR_MSG,
-    PET_MODEL_TIMEPOINT_VALUE_ERROR_MSG,
+    FIRST_TIMEPOINT_VALUE_ERROR_MSG,
+    LAST_TIMEPOINT_CONSISTENCY_ERROR_MSG,
+    TIMEPOINT_XLIM_DATA_MISSING_ERROR_MSG,
     PETModel,
 )
 
@@ -58,7 +58,9 @@ def test_petmodel_init_parameters_error(request, setup_random_pet_data, none_par
 
     with pytest.raises(
         ValueError,
-        match=re.escape(PET_MODEL_PARAMETERS_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)),
+        match=re.escape(
+            TIMEPOINT_XLIM_DATA_MISSING_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
+        ),
     ):
         PETModel(dataset=pet_obj, timepoints=timepoints, xlim=xlim)  # type: ignore[arg-type]
 
@@ -82,7 +84,7 @@ def test_petmodel_init_timepoint_value_error(request, setup_random_pet_data):
     timepoints[0] = DEFAULT_TIMEPOINT_TOL - sys.float_info.epsilon
 
     with pytest.raises(
-        ValueError, match=PET_MODEL_TIMEPOINT_VALUE_ERROR_MSG.format(timepoints=timepoints)
+        ValueError, match=FIRST_TIMEPOINT_VALUE_ERROR_MSG.format(timepoints=timepoints)
     ):
         PETModel(dataset=pet_obj, timepoints=timepoints, xlim=xlim)
 
@@ -107,7 +109,7 @@ def test_petmodel_parameter_consistency_error(request, setup_random_pet_data):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            PET_MODEL_PARAMETER_CONSISTENCY_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
+            LAST_TIMEPOINT_CONSISTENCY_ERROR_MSG.format(timepoints=timepoints, xlim=xlim)
         ),
     ):
         PETModel(dataset=pet_obj, timepoints=timepoints, xlim=xlim)


### PR DESCRIPTION
Make PET model error message variable names less verbose: remove the `PET_MODEL` prefix.