### PR TITLE
TST: Make abstract class error message compatible with Python <3.12

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -23,6 +23,8 @@
 """Unit tests exercising models."""
 
 import contextlib
+import re
+import sys
 import warnings
 from typing import List
 
@@ -92,11 +94,17 @@ class DummyDatasetNoRef:
 def test_base_model():
     from nifreeze.model.base import BaseModel
 
-    with pytest.raises(
-        TypeError,
-        match="Can't instantiate abstract class BaseModel without an implementation "
-        "for abstract method 'fit_predict'",
-    ):
+    if sys.version_info >= (3, 12):
+        expected_message = re.escape(
+            "Can't instantiate abstract class BaseModel without an implementation "
+            "for abstract method 'fit_predict'"
+        )
+    else:
+        expected_message = (
+            "Can't instantiate abstract class BaseModel with abstract method fit_predict"
+        )
+
+    with pytest.raises(TypeError, match=expected_message):
         BaseModel(None)  # type: ignore[abstract]
 
 

--- a/test/test_model_pet.py
+++ b/test/test_model_pet.py
@@ -22,6 +22,7 @@
 #
 
 import re
+import sys
 
 import numpy as np
 import pytest
@@ -38,14 +39,18 @@ from nifreeze.model.pet import (
 def test_pet_base_model():
     from nifreeze.model.pet import BasePETModel
 
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
+    if sys.version_info >= (3, 12):
+        expected_message = re.escape(
             "Can't instantiate abstract class BasePETModel without an implementation "
             "for abstract method 'fit_predict'"
-        ),
-    ):
-        BasePETModel(None, xlim=None)  # type: ignore[abstract, arg-type]
+        )
+    else:
+        expected_message = (
+            "Can't instantiate abstract class BasePETModel with abstract method fit_predict"
+        )
+
+    with pytest.raises(TypeError, match=expected_message):
+        BasePETModel(None)  # type: ignore[abstract, arg-type]
 
 
 @pytest.mark.random_pet_data(5, (4, 4, 4), np.asarray([1.0, 2.0, 3.0, 4.0, 5.0]))


### PR DESCRIPTION
Make base model instantiation type error match messages be compatible with Python <3.12 in tests.

Fixes:
```
def test_base_model():
   from nifreeze.model.base import BaseModel

>  with pytest.raises(
       TypeError,
       match="Can't instantiate abstract class BaseModel without an implementation "
       "for abstract method 'fit_predict'",
   ):
E  AssertionError: Regex pattern did not match.
E  Expected regex: "Can't instantiate abstract class BaseModel without
 an implementation for abstract method 'fit_predict'"
E  Actual message: "Can't instantiate abstract class BaseModel with
 abstract method fit_predict"
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/20214921093/job/58628222100#step:11:3712

The change was introduced in
https://github.com/python/cpython/pull/47246

and included in the Python 3.12 release:
https://docs.python.org/3.12/whatsnew/changelog.html#id207