### PR TITLE
DOC: Miscellaneous PET model documentation improvements

### DIFF
--- a/src/nifreeze/model/pet.py
+++ b/src/nifreeze/model/pet.py
@@ -155,9 +155,9 @@ class BSplinePETModel(BasePETModel):
         Parameters
         ----------
         n_ctrl : :obj:`int`, optional
-            Number of B-Spline control points. If `None`, then one control point every
-            six timepoints will be used. The less control points, the smoother is the
-            model
+            Number of B-Spline control points. If :obj:`None`, then one control
+            point every six timepoints will be used. The less control points,
+            the smoother is the model.
         order : :obj:`int`, optional
             Order of the B-Spline approximation.
         """


### PR DESCRIPTION
- DOC: Mark optional PET model parameters as such in documentation
- DOC: Highlight `None `as a built-in constant