### PR TITLE
MNT: Continue running tests until completion

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ pass_env =
   NIFREEZE_WERRORS
 extras = test
 commands =
-  pytest -svx --doctest-modules --cov nifreeze --cov-report xml \
+  pytest -sv --doctest-modules --cov nifreeze --cov-report xml \
   --junitxml=test-results.xml -v src test {posargs:-n auto}
 
 [testenv:notebooks]


### PR DESCRIPTION
Continue running tests until all have run: remove the `x` flag from the `pytest` command to avoid stopping test runs immediately after the first failure or error (fail-fast behavior).

Running all tests until completion allows to identify all side-effects of a given change at once, without waiting for multiple CI cycles, saving developer time.