### PR TITLE
MNT: Limit upper bound for `NumPy` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "nipype>=1.5.1,<2.0",
   "nitransforms>=25.0.0",
   "nireports",
-  "numpy>=1.21.3",
+  "numpy>=1.21.3,<2.4.0",
   "nest-asyncio>=1.5.1",
   "scikit-image>=0.15.0",
   "scikit-learn>=1.3.0",


### PR DESCRIPTION
Limit the upper bound for the `NumPy` version. Since version 2.4.0, `numpy.where` emits a warning if an `out` argument is not provided.

Documentation:
https://numpy.org/doc/stable/release/2.4.0-notes.html#warning-emitted-when-using-where-without-out

Fixes:
```
=============================== warnings summary ===============================
.tox/py312/lib/python3.12/site-packages/dipy/core/geometry.py:150: 4 warnings
test/test_model.py: 8 warnings
  site-packages/dipy/core/geometry.py:150:
 UserWarning: 'where' used without 'out', expect unitialized memory in output.
 If this is intentional, use out=None.
    cos = np.divide(z, r, where=r > 0)
.tox/py312/lib/python3.12/site-packages/dipy/core/geometry.py:151: 4 warnings
test/test_model.py: 8 warnings
  site-packages/dipy/core/geometry.py:151:
 UserWarning: 'where' used without 'out', expect unitialized memory in output.
 If this is intentional, use out=None.
    theta = np.arccos(cos, where=(cos >= -1) & (cos <= 1))
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- generated xml file: /home/runner/work/nifreeze/nifreeze/test-results.xml ---
=================================== Werrors ====================================
Warnings as errors: Activated.
24 warnings were raised and treated as errors.
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/20475048950/job/58837991093?pr=382#step:11:4586