### PR TITLE
STY: Provide a `numpy.dtype` or a compatible value to `get_fdata`

### DIFF
--- a/src/nifreeze/utils/ndimage.py
+++ b/src/nifreeze/utils/ndimage.py
@@ -84,4 +84,9 @@ def get_data(img: ImgT, dtype: np.dtype | str | None = None) -> np.ndarray:
     ):
         return np.asanyarray(img.dataobj, dtype=header.get_data_dtype())
 
-    return img.get_fdata(dtype=dtype if is_float else np.float32)
+    if is_float:
+        dtype_to_use = np.dtype(dtype)
+    else:
+        dtype_to_use = np.dtype(np.float32)
+
+    return img.get_fdata(dtype=dtype_to_use)


### PR DESCRIPTION
Provide a `numpy.dtype` object or something that can be converted to one to `get_fdata`. Create a `numpy.dtype` instance from the provided data type when it is not `None` and is a subtype of a floating point number, and provide a `numpy.dtype` instance of `np.float32` otherwise.

Fixes:
```
src/nifreeze/utils/ndimage.py:87: error:
 Argument "dtype" to "get_fdata" of "DataobjImage" has incompatible type
 "dtype[Any] | str | type[floating[_32Bit]] | None";
 expected "type[Any] | dtype[Any] | _HasDType[dtype[Any]] |
 _HasNumPyDType[dtype[Any]] | tuple[Any, Any] | list[Any] | _DTypeDict | str"
  [arg-type]
Found 1 error in 1 file (checked 79 source files)
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/20403647584/job/58629828486#step:8:34

Documentation:
https://numpy.org/devdocs/reference/arrays.dtypes.html#specifying-and-constructing-data-types