### PR TITLE
FIX: Do not overwrite `BaseWIModel` `fit_predict` index variable

### DIFF
--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -220,8 +220,8 @@ class BaseDWIModel(BaseModel):
                     )
                     for i, model in enumerate(self._models)
                 )
-            for subprediction, index in results:
-                predicted[index] = subprediction
+            for subprediction, rindex in results:
+                predicted[rindex] = subprediction
 
             predicted = np.hstack(predicted)
 


### PR DESCRIPTION
Do not overwrite `BaseWIModel` `fit_predict` index variable: use a different name for the chunk region index variable.

Since the `index` value is not used in subsequent statements, this had previously gone undetected.