### PR TITLE
TST: Refactor the random DWI data fixture

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -303,14 +303,12 @@ def setup_random_dwi_data(request, setup_random_gtab_data):
         request, (*vol_size, volumes), 0.0, 1.0
     )
     brainmask_dataobj = rng.choice([True, False], size=vol_size).astype(bool)
-    b0_dataobj = rng.random(vol_size, dtype="float32")
     gradients = np.column_stack((bvecs, bvals)).astype("float32")
 
     return (
         dwi_dataobj,
         affine,
         brainmask_dataobj,
-        b0_dataobj,
         gradients,
         b0_thres,
     )

--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -138,14 +138,10 @@ def test_estimator_iterator_index_match(
 ):
     dataset: Union["DummyDWIDataset", "DummyPETDataset"]  # Avoids type annotation errors
     if modality == "dwi":
-        (
-            dwi_dataobj,
-            affine,
-            brainmask_dataobj,
-            b0_dataobj,
-            gradients,
-            _,
-        ) = setup_random_dwi_data
+        dwi_dataobj, affine, brainmask_dataobj, gradients, b0_thres = setup_random_dwi_data
+
+        b0s_mask = gradients[:, -1] <= b0_thres
+        b0_dataobj = dwi_dataobj[..., b0s_mask].squeeze()
 
         dataset = DummyDWIDataset(dwi_dataobj, affine, brainmask_dataobj, b0_dataobj, gradients)
         bvals = gradients[:, -1][gradients[:, -1] > DEFAULT_LOWB_THRESHOLD]

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -270,14 +270,7 @@ def test_factory_variants(name, expected_cls, setup_random_base_data, particular
 
 @pytest.mark.parametrize("name", ["avgdwi", "averagedwi", "meandwi"])
 def test_factory_avgdwi_variants(monkeypatch, name, setup_random_dwi_data):
-    (
-        dwi_dataobj,
-        affine,
-        brainmask_dataobj,
-        _,
-        gradients,
-        _,
-    ) = setup_random_dwi_data
+    dwi_dataobj, affine, brainmask_dataobj, gradients, _ = setup_random_dwi_data
 
     dataset = DWI(
         dataobj=dwi_dataobj,

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -179,14 +179,7 @@ def test_gp_model(evals, S0, snr, hsph_dirs, bval_shell):
 
 @pytest.mark.random_dwi_data(50, (14, 16, 8), True)
 def test_dti_model_essentials(setup_random_dwi_data):
-    (
-        dwi_dataobj,
-        affine,
-        brainmask_dataobj,
-        _,
-        gradients,
-        _,
-    ) = setup_random_dwi_data
+    dwi_dataobj, affine, brainmask_dataobj, gradients, _ = setup_random_dwi_data
 
     dataset = DWI(
         dataobj=dwi_dataobj,

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -241,14 +241,7 @@ def test_parsed_dwimodel_instatiation(setup_random_dwi_data, datadir, models):
     from nifreeze.data.dmri import DWI
     from nifreeze.model import DKIModel, DTIModel
 
-    (
-        dwi_dataobj,
-        affine,
-        brainmask_dataobj,
-        b0_dataobj,
-        gradients,
-        b0_thres,
-    ) = setup_random_dwi_data
+    dwi_dataobj, affine, brainmask_dataobj, gradients, b0_thres = setup_random_dwi_data
 
     input_file = datadir / "dwi.h5"
     argv = [


### PR DESCRIPTION
Refactor the random DWI data fixture: create `n_gradients` non-null gradient DWI volumes, and return the null gradient volumes in the `b0_dataobj` object. Avoids returning null gradients both in the `dwi_dataobj` object and the `b0_dataobj` object, which is misleading.

This allows to simplify tests where the multiple b0 warning of the DWI data class is not relevant by providing the null gradients implicitly through the `dataobj` and `gradients` parameters.

Also, reduce the number of null gradients required to the `random_gtab_data` fixture to only 1 where the multiple b0 conditions does not need to be tested.

Refactor the `dwi_data_to_nifti` helper function: make the b0 dataobj optional so that it is used only when necessary. Simplifies tests.