### PR TITLE
STY: Comply with PEP 0639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,12 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Image Recognition",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
 license = "Apache-2.0"
+license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.10"
 dependencies = [
   "attrs>=24.1.0",


### PR DESCRIPTION
Comply with PEP 0639:
- Deprecate license classifiers.
- Add a `license-files` key, which must be a valid glob pattern.

Documentation:
https://peps.python.org/pep-0639