### PR TITLE
ENH: Memory-mapped data management for BaseDataset

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,13 +2,9 @@ name: Benchmark
 
 on:
   push:
-    branches:
-      - main
-      - maint/*
+    branches: ['main', 'maint/*']
   pull_request:
-    branches:
-      - main
-      - maint/*
+    branches: ['main', 'maint/*']
   # Allow job to be triggered manually from GitHub interface
   workflow_dispatch:
 

--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -3,7 +3,7 @@ name: Build docs
 
 on:
   pull_request:
-    branches: [ main, 'maint/*' ]
+    branches: ['main', 'maint/*']
 
 jobs:
   build:

--- a/.github/workflows/docs-build-update.yml
+++ b/.github/workflows/docs-build-update.yml
@@ -3,8 +3,8 @@ name: Build & update docs
 
 on:
   push:
-    branches: [ 'doc/*', 'docs/*', main, "maint/*" ]
-    tags: [ '*' ]
+    branches: ['doc/*', 'docs/*', 'main', 'maint/*']
+    tags: ['*']
 
 jobs:
   build:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -3,8 +3,8 @@ name: Build and upload package
 
 on:
   push:
-    branches: [main]
-    tags: ["*"]
+    branches: ['main']
+    tags: ['*']
   release:
     types:
       - published

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,10 +5,10 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
-    tags: [ '*' ]
+    branches: ['main']
+    tags: ['*']
   pull_request:
-    branches: [ main ]
+    branches: ['main']
   schedule:
     - cron: '0 22 * * 0' # At 22:00 UTC every Sunday
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,9 @@ name: Unit and integration tests
 
 on:
   push:
-    branches:
-      - main
-      - maint/*
+    branches: ['main', 'maint/*']
   pull_request:
-    branches:
-      - main
-      - maint/*
+    branches: ['main', 'maint/*']
   # Allow job to be triggered manually from GitHub interface
   workflow_dispatch:
   schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,11 @@ Three-layer design: **Data → Model → Estimator**
 ## Git etiquette and conventions
 
 - Semantic commit format: `<type>[(<scope>)]: <message>` — types: `fix:`, `enh:`, `sty:`, `doc:`, `mnt:`, etc. Scope parenthetical is optional.
+- Commit messages must be terse — as short as possible. Add a longer body only when the commit signals something genuinely important (something broken, a security-affecting change, major API/concern changes).
 - PR titles use uppercase (e.g., `FIX: <description>`, `ENH: <description>`, description is title-case). PRs link existing issues and other PRs if necessary in the message body, using GitHub's keywords, e.g., `Resolves: #17`, `Fixes: #19`, `X-Refs: #29`.
+- PR bodies can be less terse than commits, but must stay direct and to the point.
+- Before opening a PR, always check that there is an open issue the PR responds to. If there is none, do not open the PR — offer to open an issue instead.
+- Always open PRs as drafts, so humans do not start reviewing before the PR is ready for human review.
 - Branch names follow the convention `<type>/<identifier>[-gh<issue-number>]`. If the new branch addresses a bug/feature with an existing issue open, the issue is referenced with the optional suffix (e.g., `fix/memory-leak-gh127` for a memory leak reported in issue \#127).
 
 ## Key Conventions

--- a/src/nifreeze/data/__init__.py
+++ b/src/nifreeze/data/__init__.py
@@ -22,6 +22,8 @@
 #
 """Four-dimensional data representation in hard-disk and memory."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from nifreeze.data.base import NFDH5_EXT, BaseDataset
@@ -82,12 +84,14 @@ def load(
         return pet_from_nii(filename, brainmask_file=brainmask_file, **kwargs)
 
     img = load_api(filename, SpatialImage)
-    retval: BaseDataset = BaseDataset(dataobj=np.asanyarray(img.dataobj), affine=img.affine)
 
+    brainmask_data = None
     if brainmask_file:
         mask = load_api(brainmask_file, SpatialImage)
-        retval.brainmask = np.asanyarray(mask.dataobj)
+        brainmask_data = np.asanyarray(mask.dataobj, dtype=bool)
     else:
-        retval.brainmask = np.ones(img.shape[:3], dtype=bool)
+        brainmask_data = np.ones(img.shape[:3], dtype=bool)
 
-    return retval
+    return BaseDataset(
+        dataobj=np.asanyarray(img.dataobj), affine=img.affine, brainmask=brainmask_data
+    )

--- a/src/nifreeze/data/dmri/io.py
+++ b/src/nifreeze/data/dmri/io.py
@@ -22,6 +22,8 @@
 #
 """Input/Output utilities for DWI objects."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from warnings import warn
 

--- a/src/nifreeze/data/pet/io.py
+++ b/src/nifreeze/data/pet/io.py
@@ -22,6 +22,8 @@
 #
 """Input/Output utilities for PET objects."""
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
 

--- a/src/nifreeze/utils/ndimage.py
+++ b/src/nifreeze/utils/ndimage.py
@@ -21,6 +21,8 @@
 #     https://www.nipreps.org/community/licensing/
 #
 
+from __future__ import annotations
+
 import os
 import typing
 from warnings import warn

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -208,7 +208,7 @@ def test_load_base_nifti(
         def __init__(self, **kwargs):
             self.dataobj = kwargs["dataobj"]
             self.affine = kwargs["affine"]
-            self.brainmask = None
+            self.brainmask = kwargs.get("brainmask")
 
     monkeypatch.setattr(data, "BaseDataset", SimpleBaseDataset)
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -66,7 +66,6 @@ def test_proximity_estimator_trivial_model(datadir, tmp_path, p_error=20.0):
     )
 
     dwi_motion = DWI.from_filename(dwi_motion_path)
-    dwi_motion._filepath = tmp_path / "dwi_motion.h5"  # Prevent accidental overwriting
 
     ground_truth_affines = (
         np.copy(dwi_motion.motion_affines) if dwi_motion.motion_affines is not None else None
@@ -138,7 +137,6 @@ def test_stacked_estimators(datadir, tmp_path, monkeypatch):
 
     # Wrap into dataset object
     dwi_motion = DWI.from_filename(datadir / "dmri_data" / "motion_test_data" / "dwi_motion.h5")
-    dwi_motion._filepath = tmp_path / "dwi_motion.h5"  # Prevent accidental overwriting
     dwi_motion.motion_affines = None  # Erase ground truth for estimation
 
     def mock_iterator(*_, **kwargs):

--- a/test/test_integration_pet.py
+++ b/test/test_integration_pet.py
@@ -45,7 +45,13 @@ def test_lofo_split_shapes(tmp_path, setup_random_pet_data):
     )
 
     idx = 2
-    (train_data, train_times), (test_data, test_time) = pet_obj.lofo_split(idx)
+    # Leave-one-frame-out via indexing + _load_original_frame
+    mask = np.ones(len(pet_obj), dtype=bool)
+    mask[idx] = False
+    train_data, _, train_times = pet_obj[mask]
+    test_data = pet_obj._load_original_frame(idx)
+    test_time = pet_obj.midframe[idx]
+
     assert train_data.shape[-1] == pet_obj.dataobj.shape[-1] - 1
     np.testing.assert_array_equal(test_data, pet_obj.dataobj[..., idx])
     np.testing.assert_array_equal(train_times, np.delete(pet_obj.midframe, idx))

--- a/test/test_model_pet.py
+++ b/test/test_model_pet.py
@@ -388,66 +388,6 @@ def _plot_pet_timeseries(
     plt.close(fig)
 
 
-@pytest.mark.parametrize(
-    "x, t, cr, cri, dt, nr, match",
-    [
-        # x.size != 3
-        (
-            np.array([1.0, 2.0]),
-            np.ones(5),
-            np.ones(5),
-            np.ones(5),
-            np.ones(5),
-            5,
-            "x must have length 3",
-        ),
-        # nr mismatch with cr
-        (
-            np.array([1.0, 0.1, 2.0]),
-            np.ones(5),
-            np.ones(3),
-            np.ones(5),
-            np.ones(5),
-            5,
-            "nr must match",
-        ),
-        # nr < 1
-        (
-            np.array([1.0, 0.1, 2.0]),
-            np.ones(0),
-            np.ones(0),
-            np.ones(0),
-            np.ones(0),
-            0,
-            "nr must be >= 1",
-        ),
-        # 1 + BP == 0
-        (
-            np.array([1.0, 0.1, -1.0]),
-            np.ones(5),
-            np.ones(5),
-            np.ones(5),
-            np.ones(5),
-            5,
-            r"Invalid BP",
-        ),
-        # k2 == 0
-        (
-            np.array([1.0, 0.0, 2.0]),
-            np.ones(5),
-            np.ones(5),
-            np.ones(5),
-            np.ones(5),
-            5,
-            "k2 must be nonzero",
-        ),
-    ],
-)
-def test_srtm_validation_errors(x, t, cr, cri, dt, nr, match):
-    with pytest.raises(ValueError, match=match):
-        srtm(x=x, t=t, cr=cr, cri=cri, dt=dt, nr=nr)
-
-
 @pytest.mark.filterwarnings("ignore:No mask provided")
 def test_petmodel_fit_predict_no_brainmask():
     shape = (2, 2, 2)

--- a/test/test_simulations.py
+++ b/test/test_simulations.py
@@ -1,0 +1,87 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+
+import numpy as np
+import pytest
+
+from nifreeze.testing.simulations import srtm
+
+
+@pytest.mark.parametrize(
+    "x, t, cr, cri, dt, nr, match",
+    [
+        # x.size != 3
+        (
+            np.array([1.0, 2.0]),
+            np.ones(5),
+            np.ones(5),
+            np.ones(5),
+            np.ones(5),
+            5,
+            "x must have length 3",
+        ),
+        # nr mismatch with cr
+        (
+            np.array([1.0, 0.1, 2.0]),
+            np.ones(5),
+            np.ones(3),
+            np.ones(5),
+            np.ones(5),
+            5,
+            "nr must match",
+        ),
+        # nr < 1
+        (
+            np.array([1.0, 0.1, 2.0]),
+            np.ones(0),
+            np.ones(0),
+            np.ones(0),
+            np.ones(0),
+            0,
+            "nr must be >= 1",
+        ),
+        # 1 + BP == 0
+        (
+            np.array([1.0, 0.1, -1.0]),
+            np.ones(5),
+            np.ones(5),
+            np.ones(5),
+            np.ones(5),
+            5,
+            r"Invalid BP",
+        ),
+        # k2 == 0
+        (
+            np.array([1.0, 0.0, 2.0]),
+            np.ones(5),
+            np.ones(5),
+            np.ones(5),
+            np.ones(5),
+            5,
+            "k2 must be nonzero",
+        ),
+    ],
+)
+def test_srtm_validation_errors(x, t, cr, cri, dt, nr, match):
+    with pytest.raises(ValueError, match=match):
+        srtm(x=x, t=t, cr=cr, cri=cri, dt=dt, nr=nr)


### PR DESCRIPTION
Replace in-memory arrays with numpy memory-mapped files throughout the data layer to reduce peak RAM usage and enable subprocess sharing.

Key changes:
- Add _to_memmap() / _h5_to_memmap() helpers for streaming 4D data to disk-backed numpy memmaps without full materialization
- Replace _filepath field with _cache_dir directory for organizing memmap files and HDF5 caches
- Auto-convert dataobj and brainmask to memmap in __attrs_post_init__
- Cache original (pre-transform) dataset to HDF5 via _original_h5 for later frame-by-frame retrieval
- Add _load_original_frame() / _load_original_field() accessors
- Stream HDF5→memmap in from_filename() instead of materializing
- DWI: memmap-to-memmap b0 filtering (avoids fancy-index copy)
- PET: remove lofo_split(); use __getitem__ + _load_original_frame()
- PET: rewrite set_transform() to use _load_original_frame()
- PET: delegate to_filename()/from_filename() to base class
- Define _array_eq comparator (require_same_type=False) for memmap compatibility with attrs equality checks