### PR TITLE
FIX: Assign result of `astype` to new array

### DIFF
--- a/src/nifreeze/data/filtering.py
+++ b/src/nifreeze/data/filtering.py
@@ -110,7 +110,8 @@ def advanced_clip(
         np.subtract(1.0, data, out=data)
 
     if dtype in ("uint8", "int16"):
-        np.round(255 * data, out=data).astype(dtype)
+        np.round(255 * data, out=data)
+        data = data.astype(dtype, copy=False)
 
     if inplace:
         return None


### PR DESCRIPTION
Assign result of `astype` to new array, otherwise the statement does not actually affect the returned data.