### PR TITLE
REF: Avoid divide by zero warnings when denominator is zero

### DIFF
--- a/src/nifreeze/data/filtering.py
+++ b/src/nifreeze/data/filtering.py
@@ -104,7 +104,12 @@ def advanced_clip(
     # Clip and scale data
     np.clip(data, a_min=a_min, a_max=a_max, out=data)
     data -= data.min()
-    data /= data.max()
+    rng = float(data.max())  # rng = max-min
+    if rng != 0.0:
+        data /= rng
+    else:
+        # All values are equal after clipping: normalized result should be zeros
+        data.fill(0.0)
 
     if invert:
         np.subtract(1.0, data, out=data)

--- a/src/nifreeze/data/filtering.py
+++ b/src/nifreeze/data/filtering.py
@@ -35,6 +35,31 @@ DEFAULT_DTYPE = "int16"
 BVAL_ATOL = 100.0
 """b-value tolerance value."""
 
+CLIPPING_EMPTY_SELECTION_ERROR_MSG = """\
+Empty percentile selection after applying {constraints}finite filtering (p_min={p_min}, p_max={p_max}).
+"""
+"""Clipping empty selection error message."""
+
+CLIPPING_NONFINITE_THRESHOLDS_ERROR_MSG = """\
+Percentile thresholds are not finite (a_min={a_min}, a_max={a_max}, p_min={p_min}, p_max={p_max}, nonnegative={nonnegative}).
+"""
+"""Clipping non-finite thresholds error message."""
+
+CLIPPING_INVALID_THRESHOLDS_ERROR_MSG = """\
+Invalid percentile thresholds (a_max <= a_min) (a_min={a_min}, a_max={a_max}, p_min={p_min}, p_max={p_max}, nonnegative={nonnegative}).
+"""
+"""Clipping invalid percentile thresholds error message."""
+
+CLIPPING_DEGENERATE_RANGE_ERROR_MSG = """\
+Degenerate dynamic range after clipping/shift (den={den}, a_min={a_min}, a_max={a_max}, \
+nonnegative={nonnegative}, data_finite={data_finite}, unique~={unique}).
+"""
+"""Clipping degenerate dynamic range error message."""
+
+
+class ClippingValueError(RuntimeError):
+    """Raised when clipping cannot compute a valid clipping/scaling."""
+
 
 def advanced_clip(
     data: np.ndarray,
@@ -94,22 +119,55 @@ def advanced_clip(
     # Calculate stats on denoised version to avoid outlier bias
     denoised = median_filter(data, footprint=ball(3))
 
-    a_min = np.percentile(
-        np.asarray([denoised[denoised >= 0] if nonnegative else denoised]), p_min
-    )
-    a_max = np.percentile(
-        np.asarray([denoised[denoised >= 0] if nonnegative else denoised]), p_max
-    )
+    # Select values for percentile computation.
+    # If nonnegative=True, we must have at least one finite >=0 value.
+    sel = denoised[denoised >= 0] if nonnegative else denoised
+    sel = sel[np.isfinite(sel)]
+
+    if sel.size == 0:
+        constraints = "nonnegative constraint and " if nonnegative else ""
+        raise ClippingValueError(
+            CLIPPING_EMPTY_SELECTION_ERROR_MSG.format(
+                constraints=constraints, p_min=p_min, p_max=p_max
+            )
+        )
+
+    a_min = float(np.percentile(sel, p_min))
+    a_max = float(np.percentile(sel, p_max))
+
+    if not np.isfinite(a_min) or not np.isfinite(a_max):
+        raise ClippingValueError(
+            CLIPPING_NONFINITE_THRESHOLDS_ERROR_MSG.format(
+                a_min=a_min, a_max=a_max, p_min=p_min, p_max=p_max, nonnegative=nonnegative
+            )
+        )
+
+    if a_max <= a_min:
+        raise ClippingValueError(
+            CLIPPING_INVALID_THRESHOLDS_ERROR_MSG.format(
+                a_min=a_min, a_max=a_max, p_min=p_min, p_max=p_max, nonnegative=nonnegative
+            )
+        )
 
     # Clip and scale data
     np.clip(data, a_min=a_min, a_max=a_max, out=data)
     data -= data.min()
-    _range = float(data.max())  # rng = max-min
-    if rng != 0.0:
-        data /= _range
-    else:
-        # All values are equal after clipping: normalized result should be zeros
-        data.fill(0.0)
+    den = float(data.max())  # max-min because min is now 0
+    if not np.isfinite(den) or den == 0.0:
+        # Degenerate dynamic range after clipping
+        unique = len(np.unique(data)) if data.size < 1_000_000 else "too big"
+        raise ClippingValueError(
+            CLIPPING_DEGENERATE_RANGE_ERROR_MSG.format(
+                den=den,
+                a_min=a_min,
+                a_max=a_max,
+                nonnegative=nonnegative,
+                data_finite=bool(np.isfinite(data).all()),
+                unique=unique,
+            )
+        )
+
+    data /= den
 
     if invert:
         np.subtract(1.0, data, out=data)

--- a/src/nifreeze/data/filtering.py
+++ b/src/nifreeze/data/filtering.py
@@ -104,9 +104,9 @@ def advanced_clip(
     # Clip and scale data
     np.clip(data, a_min=a_min, a_max=a_max, out=data)
     data -= data.min()
-    rng = float(data.max())  # rng = max-min
+    _range = float(data.max())  # rng = max-min
     if rng != 0.0:
-        data /= rng
+        data /= _range
     else:
         # All values are equal after clipping: normalized result should be zeros
         data.fill(0.0)

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -22,6 +22,7 @@
 #
 
 import copy
+import warnings
 
 import numpy as np
 import pytest
@@ -35,6 +36,27 @@ from nifreeze.data.filtering import (
     grand_mean_normalization,
     robust_minmax_normalization,
 )
+
+
+@pytest.mark.parametrize(
+    ("data", "p_min", "p_max"),
+    [
+        # Constant array: after data -= data.min(), max == 0, normalization denom == 0
+        (np.full((5, 5, 5), 7.0, dtype=np.float32), 35.0, 99.98),
+        # Collapsed clip range: everything clips to one value: denom == 0
+        (np.arange(27, dtype=np.float32).reshape((3, 3, 3)), 50.0, 50.0),
+    ],
+    ids=["constant_array", "collapsed_percentiles"],
+)
+def test_advanced_clip_degenerate(data, p_min, p_max):
+    # Treat RuntimeWarnings as errors so the test fails if divide/cast warnings occur
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        clipped_data = advanced_clip(data, inplace=False, dtype="int16", p_min=p_min, p_max=p_max)
+
+    assert clipped_data is not None
+    # When dynamic range collapses, output should be all zeros
+    assert np.all(clipped_data == 0)
 
 
 @pytest.mark.random_uniform_ndim_data((32, 32, 32), 0.0, 2.0)

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -22,7 +22,6 @@
 #
 
 import copy
-import warnings
 
 import numpy as np
 import pytest
@@ -31,6 +30,11 @@ from skimage.morphology import ball
 
 from nifreeze.data.filtering import (
     BVAL_ATOL,
+    CLIPPING_DEGENERATE_RANGE_ERROR_MSG,
+    CLIPPING_EMPTY_SELECTION_ERROR_MSG,
+    CLIPPING_INVALID_THRESHOLDS_ERROR_MSG,
+    CLIPPING_NONFINITE_THRESHOLDS_ERROR_MSG,
+    ClippingValueError,
     advanced_clip,
     dwi_select_shells,
     grand_mean_normalization,
@@ -38,25 +42,81 @@ from nifreeze.data.filtering import (
 )
 
 
-@pytest.mark.parametrize(
-    ("data", "p_min", "p_max"),
-    [
-        # Constant array: after data -= data.min(), max == 0, normalization denom == 0
-        (np.full((5, 5, 5), 7.0, dtype=np.float32), 35.0, 99.98),
-        # Collapsed clip range: everything clips to one value: denom == 0
-        (np.arange(27, dtype=np.float32).reshape((3, 3, 3)), 50.0, 50.0),
-    ],
-    ids=["constant_array", "collapsed_percentiles"],
-)
-def test_advanced_clip_degenerate(data, p_min, p_max):
-    # Treat RuntimeWarnings as errors so the test fails if divide/cast warnings occur
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", RuntimeWarning)
-        clipped_data = advanced_clip(data, inplace=False, dtype="int16", p_min=p_min, p_max=p_max)
+def test_advanced_clip_empty_selection():
+    data = -np.ones((5, 5, 5), dtype=np.float32)
 
-    assert clipped_data is not None
-    # When dynamic range collapses, output should be all zeros
-    assert np.all(clipped_data == 0)
+    with pytest.raises(ClippingValueError) as exc:
+        advanced_clip(data, inplace=False, nonnegative=True)
+
+    expected = CLIPPING_EMPTY_SELECTION_ERROR_MSG.format(
+        constraints="nonnegative constraint and ", p_min=35.0, p_max=99.98
+    )
+    assert str(exc.value) == expected
+
+
+def test_advanced_clip_nonfinite_thresholds(monkeypatch):
+    data = np.ones((5, 5, 5), dtype=np.float32)
+
+    # Force non-finite thresholds regardless of input data
+    def _percentile_returns_nan(*args, **kwargs):
+        return np.nan
+
+    from nifreeze.data import filtering
+
+    monkeypatch.setattr(filtering.np, "percentile", _percentile_returns_nan)
+
+    with pytest.raises(ClippingValueError) as exc:
+        advanced_clip(data, inplace=False, nonnegative=True, p_min=35.0, p_max=99.98)
+
+    expected = CLIPPING_NONFINITE_THRESHOLDS_ERROR_MSG.format(
+        a_min=float("nan"), a_max=float("nan"), p_min=35.0, p_max=99.98, nonnegative=True
+    )
+    assert str(exc.value) == expected
+
+
+def test_advanced_clip_invalid_thresholds():
+    data = np.arange(27, dtype=np.float32).reshape((3, 3, 3))
+    p = 50.0
+
+    with pytest.raises(ClippingValueError) as exc:
+        advanced_clip(data, inplace=False, nonnegative=True, p_min=p, p_max=p)
+
+    # With p_min == p_max, percentiles are equal (deterministically for this data)
+    sel = data[np.isfinite(data)]
+    a = float(np.percentile(sel, p))
+    expected = CLIPPING_INVALID_THRESHOLDS_ERROR_MSG.format(
+        a_min=a, a_max=a, p_min=p, p_max=p, nonnegative=True
+    )
+    assert str(exc.value) == expected
+
+
+def test_advanced_clip_degenerate_range(monkeypatch):
+    data = np.arange(27, dtype=np.float32).reshape((3, 3, 3))
+
+    # Ensure thresholds are valid (a_max > a_min) and deterministic.
+    # advanced_clip calls np.percentile twice (for a_min and a_max).
+    percentiles = iter([0.0, 1.0])
+
+    def _percentile(_arr, _q):
+        return next(percentiles)
+
+    monkeypatch.setattr(np, "percentile", _percentile)
+
+    # Force clipping to collapse all values to a constant after thresholds are deemed valid
+    def _clip(_data, a_min=None, a_max=None, out=None):
+        out.fill(0.5)
+        return out
+
+    monkeypatch.setattr(np, "clip", _clip)
+
+    with pytest.raises(ClippingValueError) as exc:
+        advanced_clip(data, inplace=False, nonnegative=True, p_min=35.0, p_max=99.98)
+
+    # After our fake clip: data is constant 0.5; subtract min: all zeros; den == 0.0
+    expected = CLIPPING_DEGENERATE_RANGE_ERROR_MSG.format(
+        den=0.0, a_min=0.0, a_max=1.0, nonnegative=True, data_finite=True, unique=1
+    )
+    assert str(exc.value) == expected
 
 
 @pytest.mark.random_uniform_ndim_data((32, 32, 32), 0.0, 2.0)


### PR DESCRIPTION
Avoid divide by zero warnings when denominator is zero: check that values are nonzero before dividing; else, set all values to zero.

Add the corresponding tests.

Fixes:
```
test/test_integration.py: 15 warnings
    /home/runner/work/nifreeze/nifreeze/src/nifreeze/data/filtering.py:107:
    RuntimeWarning: invalid value encountered in divide
          data /= data.max()
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/24288044855/job/70920601980?pr=313