### PR TITLE
REF: Keep DWI model predictions as floats until deliberate cast

### DIFF
--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -381,7 +381,8 @@ class BaseDWIModel(BaseModel):
 
             predicted = np.hstack(predicted)
 
-        retval = np.zeros_like(self._data_mask, dtype=self._dataset.dataobj.dtype)
+        out_dtype = np.result_type(predicted.dtype, np.float32)
+        retval = np.zeros(self._data_mask.shape, dtype=out_dtype)
         retval[self._data_mask, ...] = predicted
         return retval
 


### PR DESCRIPTION
Keep DWI model predictions as floats until deliberate cast.

Predicted values may be floating point numbers. However, the returned value array was being created with the original data type, which may be of integer type. Thus, the data need to be castd during the assignment operation, and hence, values can overflow.

Fixes:
```
test/test_integration.py: 10 warnings
    /home/runner/work/nifreeze/nifreeze/src/nifreeze/model/dmri.py:385:
    RuntimeWarning: overflow encountered in cast
          retval[self._data_mask, ...] = predicted
```

raised for example at:
https://github.com/nipreps/nifreeze/actions/runs/24288044855/job/70920601980?pr=313#step:12:5829