### PR TITLE
FIX: Replace Removed `matplotlib.cm.get_cmap` and Pin Matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "attrs>=24.1.0",
   "dipy>=1.5.0",
   "joblib",
+  "matplotlib~=3.11.0",
   "nipype>=1.11.0,<2.0",
   "nitransforms>=25.0.0",
   "nireports",
@@ -43,7 +44,6 @@ NiPreps = "https://www.nipreps.org/"
 [project.optional-dependencies]
 doc = [
   "furo>=2024.01.29",
-  "matplotlib>=2.2.0",
   "nbsphinx",
   "packaging",
   "pydot>=1.2.3",

--- a/src/nifreeze/viz/motion_viz.py
+++ b/src/nifreeze/viz/motion_viz.py
@@ -23,11 +23,11 @@
 
 from typing import Union
 
-import matplotlib.cm as cm
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib import colormaps
 from matplotlib.axes import Axes
 from scipy.ndimage import gaussian_filter
 
@@ -109,7 +109,7 @@ def plot_framewise_displacement(
     # Plot the framewise displacement
     n_frames = fd.index.to_numpy()
 
-    cmap = cm.get_cmap(cmap_name, n_cols)
+    cmap = colormaps[cmap_name].resampled(n_cols)
     colors = [mcolors.to_hex(cmap(i)) for i in range(n_cols)]
 
     for i, col in enumerate(fd.columns):


### PR DESCRIPTION
## What

`matplotlib` 3.11 **removed** `matplotlib.cm.get_cmap` (deprecated since 3.7), which broke CI on `main` (run 27439125402): both the `checks (typecheck)` job (mypy `attr-defined`) and the `stable (3.12)` job (`AttributeError` in `test_plot_framewise_displacement`) failed at `src/nifreeze/viz/motion_viz.py:112`.

## Changes

- Replace `cm.get_cmap(cmap_name, n_cols)` with the canonical registry API `colormaps[cmap_name].resampled(n_cols)`.
- Add `matplotlib~=3.11.0` as a direct (core) dependency. `viz/motion_viz.py` imports matplotlib at module level, and the failing `test`/`typecheck` envs only pulled it transitively (via `nireports`) — so the pin must live in core deps to actually constrain those environments. Removed the now-redundant `matplotlib>=2.2.0` from the `doc` extra.

## Verification

- `tox -e typecheck` → `Success: no issues found in 83 source files`.
- `pytest test/test_motion_viz.py` → 5 passed.

Fixes: #444