### PR TITLE
MNT: Bump DIPY to current HEAD for multi voxel decorator arg management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.10"
 dependencies = [
   "attrs>=24.1.0",
-  "dipy>=1.5.0",
+  "dipy @ git+https://github.com/dipy/dipy.git@2ecd3655",
   "joblib",
   "matplotlib>=2.2.0,<3.11; python_version == '3.10'",
   "matplotlib>=3.11; python_version > '3.10'",


### PR DESCRIPTION
Bump DIPY to current `HEAD` so that the fixes to the orchestration argument management in the multi voxel fit decorator can be used in NiFreeze:
https://github.com/dipy/dipy/pull/4054