### PR TITLE
TST: Fix `random_dataset` fixture for pytest 9.1.x

### DIFF
--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -133,15 +133,12 @@ class DummyDataset(BaseDataset):
         return (self.dataobj[..., idx],)
 
 
-@pytest.mark.parametrize(
-    "setup_random_uniform_spatial_data",
-    [
-        (DEFAULT_RANDOM_DATASET_SHAPE, 0.0, 1.0),
-    ],
-)
 @pytest.fixture
-def random_dataset(setup_random_uniform_spatial_data) -> BaseDataset:
+def random_dataset(request, setup_random_uniform_spatial_data) -> BaseDataset:
     """Create a BaseDataset with random data for testing."""
+
+    shape, low, high = getattr(request, "param", (DEFAULT_RANDOM_DATASET_SHAPE, 0.0, 1.0))
+    request.node.add_marker(pytest.mark.random_uniform_spatial_data(shape, low, high))
 
     data, affine = setup_random_uniform_spatial_data
     return BaseDataset(dataobj=data, affine=affine)


### PR DESCRIPTION
Replace the fixture-level parametrization on `random_dataset` with fixture logic that reads optional `request.param` values and applies `random_uniform_spatial_data(shape, low, high)` at runtime before consuming `setup_random_uniform_spatial_data`.

Keeps a default creation path while allowing per-test custom generation via indirect parametrization with `(shape, low, high)` tuples, e.g.:
```
@pytest.mark.parametrize(
    "random_dataset",
    [
       ((16, 16, 16, 3), -1.0, 1.0)
    ],
    indirect=True,
)
def test_something_with_custom_dataset(random_dataset: BaseDataset):
    (...)
```

This updates `test_data_base.py` to use a pytest-9.1.x-compatible pattern while enabling targeted dataset customization from individual tests.

Fixes:
```
 test/test_data_base.py:136: in <module>
     @pytest.mark.parametrize(
 .tox/py312/lib/python3.12/site-packages/_pytest/mark/structures.py:415: in __call__
     store_mark(unwrapped_func, self.mark)
 .tox/py312/lib/python3.12/site-packages/_pytest/mark/structures.py:491: in store_mark
     fail(
 E   Failed: Marks cannot be applied to fixtures.
 E  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/28817274832/job/85459859288