### PR TITLE
FIX: Revise DKI model initialization to leverage DIPY's ``multi_voxel_fit``

### DIFF
--- a/src/nifreeze/estimator.py
+++ b/src/nifreeze/estimator.py
@@ -159,10 +159,6 @@ class Estimator:
             if self._model.endswith("dti"):
                 self._model_kwargs["step"] = chunk_size
 
-            # Example: change model parameters only for DKI
-            # if self._model.endswith("dki"):
-            #     self._model_kwargs["fit_model"] = "CWLS"
-
             # Factory creates the appropriate model and pipes arguments
             model = ModelFactory.init(
                 model=self._model,

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -198,6 +198,12 @@ class BaseDWIModel(BaseModel):
         "_models": "List with one or more (if parallel execution) model instances",
     }
 
+    _multivoxel_engine: bool = False
+    """Whether the underlying model fits per-voxel through DIPY's
+    ``multi_voxel_fit`` and therefore supports DIPY-native parallelization
+    (``engine``/``n_jobs``). Models that do not (DTI, GQI, GP) are parallelized
+    by chunking the data across workers instead."""
+
     def __init__(self, dataset: DWI, max_b: float | int | None = None, **kwargs):
         """Initialization.
 
@@ -257,7 +263,7 @@ class BaseDWIModel(BaseModel):
         n_jobs = n_jobs or 1
 
         if self._locked_fit is not None:
-            return n_jobs
+            return len(self._models)
 
         brainmask = self._dataset.brainmask
         idxmask = np.ones(len(self._dataset), dtype=bool)
@@ -279,7 +285,8 @@ class BaseDWIModel(BaseModel):
         # Append the b0 (if existing) to the gradients and the data for the
         # kurtosis model.
         # Appending instead of prepending avoids index manipulation.
-        if "DiffusionKurtosisModel" in model_str:
+        is_dki = "DiffusionKurtosisModel" in model_str
+        if is_dki:
             bzero = self._dataset.bzero
             if bzero is not None:
                 bzero = (
@@ -291,6 +298,10 @@ class BaseDWIModel(BaseModel):
 
         if model_str:
             module_name, class_name = model_str.rsplit(".", 1)
+
+            if self._multivoxel_engine and n_jobs > 1:
+                kwargs = kwargs | {"engine": "joblib", "n_jobs": n_jobs}
+
             model = getattr(
                 import_module(module_name),
                 class_name,
@@ -300,16 +311,9 @@ class BaseDWIModel(BaseModel):
 
         fit_kwargs: dict[str, Any] = {}  # Add here keyword arguments
 
-        is_dki = model_str == "dipy.reconst.dki.DiffusionKurtosisModel"
-
-        # One single CPU - linear execution (full model)
-        # DKI model does not allow parallelization as implemented here
-        if n_jobs == 1 or is_dki:
+        # Models not using DIPY's multi_voxel_fit split the fitting.
+        if n_jobs == 1 or self._multivoxel_engine:
             _modelfit, _ = _exec_fit(model, data, **fit_kwargs)
-            self._models = [_modelfit]
-            return 1
-        elif is_dki:
-            _modelfit = model.multi_fit(data, **fit_kwargs)
             self._models = [_modelfit]
             return 1
 
@@ -473,6 +477,7 @@ class DKIModel(BaseDWIModel):
 
     _modelargs = DTIModel._modelargs
     _model_class = "dipy.reconst.dki.DiffusionKurtosisModel"
+    _multivoxel_engine = True
 
 
 class GQIModel(BaseDWIModel):

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -255,6 +255,9 @@ class BaseDWIModel(BaseModel):
             dataset.dataobj, self._data_mask, dataset.bzero, ignore_bzero=ignore_bzero
         )
 
+        # Fitted model instance(s); populated in ``_fit``.
+        self._models: list[Any] = []
+
         super().__init__(dataset, **kwargs)
 
     def _fit(self, index: int | None = None, n_jobs: int | None = None, **kwargs) -> int:

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -1099,6 +1099,48 @@ def test_dki_parallel_matches_serial(multi_shell_test_data, index, use_mask):
 
 
 @pytest.mark.parametrize(
+    "multi_shell_test_data",
+    [
+        {
+            "bval_shell": (1000, 2000, 3000),
+            "S0": 1,
+            "evals": (0.0015, 0.0003, 0.0003),
+            "hsph_dirs": (5, 6, 7),
+            "snr": None,
+            "vol_shape": (4, 4, 3),
+            "add_bzero": True,
+        },
+    ],
+    indirect=True,
+)
+def test_dki_single_fit_locked_reuse(multi_shell_test_data):
+    """Single-fit mode locks one DKI model and reuses it for every prediction.
+
+    Exercises the ``_locked_fit`` early return in ``_fit``
+    (``return len(self._models)``): it must yield 1 for DKI's single,
+    internally-parallel model so the single-model predict path is taken and the
+    whole volume is predicted (not just ``1 / n_jobs`` of it).
+    """
+    dataset, _, _, _ = setup_multi_shell_fit_predict_data(
+        multi_shell_test_data, ignore_bzero=False, use_mask=False
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
+        dkimodel = model.DKIModel(dataset)
+        # Single-fit (index=None) locks a single, internally-parallel model.
+        assert dkimodel.fit_predict(None, n_jobs=2) is None
+        assert dkimodel._locked_fit is not None
+        assert len(dkimodel._models) == 1
+        # Subsequent predictions reuse the locked fit via the early return.
+        predicted = dkimodel.fit_predict(4, n_jobs=2)
+
+    assert predicted is not None
+    assert predicted.shape == dataset.dataobj.shape[:-1]
+    assert np.any(predicted != 0)
+
+
+@pytest.mark.parametrize(
     ("bval_shell", "S0", "evals"),
     [(1000, 100, (0.0015, 0.0003, 0.0003))],
 )

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -1141,6 +1141,49 @@ def test_dki_single_fit_locked_reuse(multi_shell_test_data):
 
 
 @pytest.mark.parametrize(
+    "single_shell_test_data",
+    [
+        {
+            "bval_shell": 1000,
+            "S0": 100,
+            "evals": (0.0015, 0.0003, 0.0003),
+            "hsph_dirs": 30,
+            "snr": None,
+            "vol_shape": (4, 4, 3),
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("index", (4, 9))
+def test_dti_parallel_matches_serial(single_shell_test_data, index):
+    """Non-multivoxel models parallelize by chunking the data across workers.
+
+    Exercises the ``n_jobs > 1`` data-chunking branch of ``_fit`` taken by
+    models that do not use DIPY's ``multi_voxel_fit`` (here, DTI). Because
+    voxel-wise fitting is independent, the chunked result must match the serial
+    (``n_jobs == 1``) path.
+    """
+    dataset, _, _, _ = setup_single_shell_fit_predict_data(
+        single_shell_test_data, ignore_bzero=False, use_mask=False
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*(invalid value encountered in divide|divide by zero encountered in log).*",
+            category=RuntimeWarning,
+        )
+        serial = model.DTIModel(dataset).fit_predict(index, n_jobs=1)
+        parallel = model.DTIModel(dataset).fit_predict(index, n_jobs=2)
+
+    assert serial is not None
+    assert parallel is not None
+    assert serial.shape == parallel.shape
+    assert np.allclose(serial, parallel, rtol=1e-5, atol=1e-6, equal_nan=True)
+
+
+@pytest.mark.parametrize(
     ("bval_shell", "S0", "evals"),
     [(1000, 100, (0.0015, 0.0003, 0.0003))],
 )

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -993,6 +993,112 @@ def test_dki_model_predict(multi_shell_test_data, index, ignore_bzero, use_mask)
 
 
 @pytest.mark.parametrize(
+    "multi_shell_test_data",
+    [
+        {
+            "bval_shell": (1000, 2000, 3000),
+            "S0": 1,
+            "evals": (0.0015, 0.0003, 0.0003),
+            "hsph_dirs": (5, 6, 7),
+            "snr": None,
+            "vol_shape": (4, 4, 3),
+            "add_bzero": True,
+        },
+    ],
+    indirect=True,
+)
+def test_dki_dispatches_dipy_native_parallel(multi_shell_test_data, monkeypatch):
+    """``n_jobs > 1`` must switch DKI onto DIPY's parallel ``multi_voxel_fit``.
+
+    The switch is observable as the ``DiffusionKurtosisModel`` being constructed
+    with ``engine="joblib", n_jobs=N``, which routes ``multi_fit`` through the
+    parallel branch of DIPY's ``multi_voxel_fit`` decorator. With ``n_jobs == 1``
+    no ``engine`` is passed and DKI fits serially. See gh-442.
+    """
+
+    class _SpyDKIModel(dki.DiffusionKurtosisModel):
+        calls: list[dict] = []
+
+        def __init__(self, gtab, *args, **kwargs):
+            type(self).calls.append(dict(kwargs))
+            # Strip the orchestration kwargs so the (serial) real fit runs and
+            # the assertion stays a pure dispatch contract.
+            for key in ("engine", "n_jobs", "vox_per_chunk", "verbose"):
+                kwargs.pop(key, None)
+            super().__init__(gtab, *args, **kwargs)
+
+    dataset, _, _, _ = setup_multi_shell_fit_predict_data(
+        multi_shell_test_data, ignore_bzero=False, use_mask=False
+    )
+
+    # NiFreeze builds the model via ``import_module(...).DiffusionKurtosisModel``,
+    # so patching the module attribute intercepts construction inside ``_fit``.
+    monkeypatch.setattr("dipy.reconst.dki.DiffusionKurtosisModel", _SpyDKIModel)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
+
+        _SpyDKIModel.calls = []
+        model.DKIModel(dataset).fit_predict(4, n_jobs=1)
+        assert _SpyDKIModel.calls
+        assert all("engine" not in call for call in _SpyDKIModel.calls)
+
+        # With n_jobs > 1, an engine argument is passed to DIPY's DKI model
+        _SpyDKIModel.calls = []
+        model.DKIModel(dataset).fit_predict(4, n_jobs=4)
+        assert any(
+            call.get("engine") == "joblib" and call.get("n_jobs") == 4
+            for call in _SpyDKIModel.calls
+        )
+
+    # The DIPY-native engine is a per-model capability: only multi_voxel_fit
+    # models declare it. DTI/GQI/GP keep the data-chunking path.
+    assert model.dmri.DKIModel._multivoxel_engine is True
+    assert model.dmri.DTIModel._multivoxel_engine is False
+    assert model.dmri.GQIModel._multivoxel_engine is False
+    assert model.dmri.GPModel._multivoxel_engine is False
+
+
+@pytest.mark.parametrize(
+    "multi_shell_test_data",
+    [
+        {
+            "bval_shell": (1000, 2000, 3000),
+            "S0": 1,
+            "evals": (0.0015, 0.0003, 0.0003),
+            "hsph_dirs": (5, 6, 7),
+            "snr": None,
+            "vol_shape": (4, 4, 3),
+            "add_bzero": True,
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("index", (4, 9))
+@pytest.mark.parametrize("use_mask", (False, True))
+def test_dki_parallel_matches_serial(multi_shell_test_data, index, use_mask):
+    """DIPY-native parallel DKI fit/predict must match the serial path exactly.
+
+    Voxel-wise fitting is independent, so ``n_jobs > 1`` (DIPY's ``joblib``
+    engine) must be numerically identical to the serial (``n_jobs == 1``) path.
+    Regression test for gh-442.
+    """
+    dataset, _, _, _ = setup_multi_shell_fit_predict_data(
+        multi_shell_test_data, ignore_bzero=False, use_mask=use_mask
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
+        serial = model.DKIModel(dataset).fit_predict(index, n_jobs=1)
+        parallel = model.DKIModel(dataset).fit_predict(index, n_jobs=4)
+
+    assert serial is not None
+    assert parallel is not None
+    assert serial.shape == parallel.shape
+    assert np.allclose(serial, parallel, rtol=1e-5, atol=1e-6, equal_nan=True)
+
+
+@pytest.mark.parametrize(
     ("bval_shell", "S0", "evals"),
     [(1000, 100, (0.0015, 0.0003, 0.0003))],
 )


### PR DESCRIPTION
After the patching of the decorator (dipy/dipy#4054), this PR adapts the model initialization to use DIPY's parallelization.

The PR includes tests to ensure the right fit functions inside DIPY's models are called.