### PR TITLE
MNT: Bump `virtualenv` dependency in benchmark table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ antsopt = [
 benchmark = [
   "asv",
   "pyperf",
-  "virtualenv==20.30",
+  "virtualenv==20.38.0",
 ]
 
 # Aliases


### PR DESCRIPTION
Bump `virtualenv` dependency in benc<hmark table to address a TOCTOU (Time-of-Check Time-of-Use) vulnerability flagged by Dependabot.

Further information:
https://github.com/nipreps/nifreeze/security/dependabot/2