### PR TITLE
RF: The adopton of multi_voxel_fit from DIPY is not immediate

### DIFF
--- a/src/nifreeze/model/dki.py
+++ b/src/nifreeze/model/dki.py
@@ -27,25 +27,10 @@ from dipy.reconst.dki import DiffusionKurtosisModel as _DipyDKIModel
 
 
 class DiffusionKurtosisModel(_DipyDKIModel):
-    """A :obj:`~dipy.reconst.dki.DiffusionKurtosisModel` accepting engine kwargs at fit time.
-
-    DIPY decorates DKI's ``multi_fit`` (not ``fit``) with ``multi_voxel_fit``, so
-    stock DKI only accepts the parallelization arguments (``engine``, ``n_jobs``,
-    ...) through the *constructor*, unlike every other multi-voxel model, which
-    accepts them at *fit* time. This subclass overrides ``fit`` to forward
-    call-time orchestration kwargs into the already-decorated ``multi_fit``,
-    giving DKI the same decorated-``fit`` interface and letting NiFreeze
-    parallelize it uniformly with the other models.
-    """
+    """A :obj:`~dipy.reconst.dki.DiffusionKurtosisModel` with uniform API."""
 
     def fit(self, data, *, mask=None, **kwargs):
-        """Fit the DKI model, forwarding orchestration kwargs to ``multi_fit``.
-
-        The serial/delegate path (no orchestration kwargs) preserves stock
-        behavior, including populating ``self.extra`` for iterative/robust fits.
-        The parallel path is only taken for the standard (WLS/OLS) multi-voxel
-        methods, whose ``multi_fit`` carries no ``extra`` diagnostics.
-        """
+        """Fit the model to data."""
         # No orchestration kwargs, or a path multi_fit does not cover: delegate.
         if not kwargs or not self.is_multi_method or self.is_iter_method:
             return super().fit(data, mask=mask)

--- a/src/nifreeze/model/dki.py
+++ b/src/nifreeze/model/dki.py
@@ -1,0 +1,56 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""A diffusion kurtosis imaging (DKI) model with a normalized ``fit`` interface."""
+
+import numpy as np
+from dipy.reconst.dki import DiffusionKurtosisModel as _DipyDKIModel
+
+
+class DiffusionKurtosisModel(_DipyDKIModel):
+    """A :obj:`~dipy.reconst.dki.DiffusionKurtosisModel` accepting engine kwargs at fit time.
+
+    DIPY decorates DKI's ``multi_fit`` (not ``fit``) with ``multi_voxel_fit``, so
+    stock DKI only accepts the parallelization arguments (``engine``, ``n_jobs``,
+    ...) through the *constructor*, unlike every other multi-voxel model, which
+    accepts them at *fit* time. This subclass overrides ``fit`` to forward
+    call-time orchestration kwargs into the already-decorated ``multi_fit``,
+    giving DKI the same decorated-``fit`` interface and letting NiFreeze
+    parallelize it uniformly with the other models.
+    """
+
+    def fit(self, data, *, mask=None, **kwargs):
+        """Fit the DKI model, forwarding orchestration kwargs to ``multi_fit``.
+
+        The serial/delegate path (no orchestration kwargs) preserves stock
+        behavior, including populating ``self.extra`` for iterative/robust fits.
+        The parallel path is only taken for the standard (WLS/OLS) multi-voxel
+        methods, whose ``multi_fit`` carries no ``extra`` diagnostics.
+        """
+        # No orchestration kwargs, or a path multi_fit does not cover: delegate.
+        if not kwargs or not self.is_multi_method or self.is_iter_method:
+            return super().fit(data, mask=mask)
+
+        data_thres = np.maximum(data, self.min_signal)
+        return self.multi_fit(
+            data_thres, mask=mask, weights=self.weights, **{**self.kwargs, **kwargs}
+        )[0]

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -272,9 +272,10 @@ class BaseDWIModel(BaseModel):
         # Select voxels within mask or just unravel 3D if no mask
         data = data[brainmask, ...] if brainmask is not None else data.reshape(-1, data.shape[-1])
 
-        # All BaseDWIModel subclasses expect a DIPY GradientTable.
-        model_str = getattr(self, "_model_class", "")
+        # Replace the gradient table with a DIPY object
         gtab = gradient_table_from_bvals_bvecs(gtab[:, -1], gtab[:, :-1])
+
+        model_str = getattr(self, "_model_class", "")
 
         # Append the b0 (if existing) to the gradients and the data for the
         # kurtosis model.
@@ -297,23 +298,16 @@ class BaseDWIModel(BaseModel):
         module_name, class_name = model_str.rsplit(".", 1)
         model = getattr(import_module(module_name), class_name)(gtab, **kwargs)
 
-        # DIPY-native models parallelize per-voxel internally when handed
-        # engine/n_jobs at fit time (a single, in-process fit). Models whose fit
-        # rejects these raise TypeError; fall back to nifreeze's data-chunking.
-        if n_jobs > 1:
-            try:
-                _modelfit, _ = _exec_fit(model, data, engine="joblib", n_jobs=n_jobs)
-                self._models = [_modelfit]
-                return 1
-            except TypeError:
-                pass
-
-        if n_jobs == 1:
-            _modelfit, _ = _exec_fit(model, data)
+        pargs = {} if n_jobs == 1 else {"engine": "joblib", "n_jobs": n_jobs}
+        try:
+            _modelfit, _ = _exec_fit(model, data, **pargs)
             self._models = [_modelfit]
             return 1
+        except TypeError:
+            if n_jobs == 1:
+                raise
 
-        # Split data into chunks of group of slices
+        # Fallback to nifreeze's parallelization if standard raised
         data_chunks = np.array_split(data, n_jobs)
 
         self._models = [None] * n_jobs

--- a/src/nifreeze/model/dmri.py
+++ b/src/nifreeze/model/dmri.py
@@ -198,12 +198,6 @@ class BaseDWIModel(BaseModel):
         "_models": "List with one or more (if parallel execution) model instances",
     }
 
-    _multivoxel_engine: bool = False
-    """Whether the underlying model fits per-voxel through DIPY's
-    ``multi_voxel_fit`` and therefore supports DIPY-native parallelization
-    (``engine``/``n_jobs``). Models that do not (DTI, GQI, GP) are parallelized
-    by chunking the data across workers instead."""
-
     def __init__(self, dataset: DWI, max_b: float | int | None = None, **kwargs):
         """Initialization.
 
@@ -263,8 +257,6 @@ class BaseDWIModel(BaseModel):
     def _fit(self, index: int | None = None, n_jobs: int | None = None, **kwargs) -> int:
         """Fit the model chunk-by-chunk asynchronously"""
 
-        n_jobs = n_jobs or 1
-
         if self._locked_fit is not None:
             return len(self._models)
 
@@ -280,10 +272,9 @@ class BaseDWIModel(BaseModel):
         # Select voxels within mask or just unravel 3D if no mask
         data = data[brainmask, ...] if brainmask is not None else data.reshape(-1, data.shape[-1])
 
-        # DIPY models (or one with a fully-compliant interface)
+        # All BaseDWIModel subclasses expect a DIPY GradientTable.
         model_str = getattr(self, "_model_class", "")
-        if "dipy" in model_str or "GeneralizedQSamplingModel" in model_str:
-            gtab = gradient_table_from_bvals_bvecs(gtab[:, -1], gtab[:, :-1])
+        gtab = gradient_table_from_bvals_bvecs(gtab[:, -1], gtab[:, :-1])
 
         # Append the b0 (if existing) to the gradients and the data for the
         # kurtosis model.
@@ -299,24 +290,26 @@ class BaseDWIModel(BaseModel):
                 )
             data, gtab = _append_bzero(data, gtab, bzero=bzero)
 
-        if model_str:
-            module_name, class_name = model_str.rsplit(".", 1)
-
-            if self._multivoxel_engine and n_jobs > 1:
-                kwargs = kwargs | {"engine": "joblib", "n_jobs": n_jobs}
-
-            model = getattr(
-                import_module(module_name),
-                class_name,
-            )(gtab, **kwargs)
-        else:
+        n_jobs = n_jobs or 1
+        if not model_str:
             raise NotImplementedError(f"{model_str} not implemented.")
 
-        fit_kwargs: dict[str, Any] = {}  # Add here keyword arguments
+        module_name, class_name = model_str.rsplit(".", 1)
+        model = getattr(import_module(module_name), class_name)(gtab, **kwargs)
 
-        # Models not using DIPY's multi_voxel_fit split the fitting.
-        if n_jobs == 1 or self._multivoxel_engine:
-            _modelfit, _ = _exec_fit(model, data, **fit_kwargs)
+        # DIPY-native models parallelize per-voxel internally when handed
+        # engine/n_jobs at fit time (a single, in-process fit). Models whose fit
+        # rejects these raise TypeError; fall back to nifreeze's data-chunking.
+        if n_jobs > 1:
+            try:
+                _modelfit, _ = _exec_fit(model, data, engine="joblib", n_jobs=n_jobs)
+                self._models = [_modelfit]
+                return 1
+            except TypeError:
+                pass
+
+        if n_jobs == 1:
+            _modelfit, _ = _exec_fit(model, data)
             self._models = [_modelfit]
             return 1
 
@@ -328,8 +321,7 @@ class BaseDWIModel(BaseModel):
         # Parallelize process with joblib
         with Parallel(n_jobs=n_jobs) as executor:
             results = executor(
-                delayed(_exec_fit)(model, dchunk, i, **fit_kwargs)
-                for i, dchunk in enumerate(data_chunks)
+                delayed(_exec_fit)(model, dchunk, i) for i, dchunk in enumerate(data_chunks)
             )
         for submodel, rindex in results:
             self._models[rindex] = submodel
@@ -359,11 +351,9 @@ class BaseDWIModel(BaseModel):
 
         gradient = self._dataset.gradients[index, :]
 
-        model_str = getattr(self, "_model_class", "")
-        if "dipy" in model_str or "GeneralizedQSamplingModel" in model_str:
-            gradient = gradient_table_from_bvals_bvecs(
-                gradient[np.newaxis, -1], gradient[np.newaxis, :-1]
-            )
+        gradient = gradient_table_from_bvals_bvecs(
+            gradient[np.newaxis, -1], gradient[np.newaxis, :-1]
+        )
 
         if n_models == 1:
             predicted, _ = _exec_predict(
@@ -476,11 +466,10 @@ class DTIModel(BaseDWIModel):
 
 
 class DKIModel(BaseDWIModel):
-    """A wrapper of :obj:`dipy.reconst.dki.DiffusionKurtosisModel`."""
+    """A wrapper of :obj:`~nifreeze.model.dki.DiffusionKurtosisModel`."""
 
     _modelargs = DTIModel._modelargs
-    _model_class = "dipy.reconst.dki.DiffusionKurtosisModel"
-    _multivoxel_engine = True
+    _model_class = "nifreeze.model.dki.DiffusionKurtosisModel"
 
 
 class GQIModel(BaseDWIModel):

--- a/src/nifreeze/model/gqi.py
+++ b/src/nifreeze/model/gqi.py
@@ -104,7 +104,7 @@ class GeneralizedQSamplingModel(ReconstModel):
             method=self.method,
         ).T
 
-    def fit(self, data, **kwargs):
+    def fit(self, data, *, mask=None):
         return GeneralizedQSamplingFit(self, data)
 
     def predict(self, odf, *, S0=None):

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -1065,6 +1065,39 @@ def test_dki_dispatches_dipy_native_parallel(multi_shell_test_data, monkeypatch)
     ],
     indirect=True,
 )
+def test_serial_fit_typeerror_reraises(multi_shell_test_data, monkeypatch):
+    """A ``TypeError`` raised from a serial (``n_jobs == 1``) fit must propagate."""
+
+    class _RaisingDKIModel(_NFDKIModel):
+        def fit(self, data, *, mask=None, **kwargs):
+            raise TypeError("boom")
+
+    dataset, _, _, _ = setup_multi_shell_fit_predict_data(
+        multi_shell_test_data, ignore_bzero=False, use_mask=False
+    )
+    monkeypatch.setattr("nifreeze.model.dki.DiffusionKurtosisModel", _RaisingDKIModel)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
+        with pytest.raises(TypeError, match="boom"):
+            model.DKIModel(dataset).fit_predict(4, n_jobs=1)
+
+
+@pytest.mark.parametrize(
+    "multi_shell_test_data",
+    [
+        {
+            "bval_shell": (1000, 2000, 3000),
+            "S0": 1,
+            "evals": (0.0015, 0.0003, 0.0003),
+            "hsph_dirs": (5, 6, 7),
+            "snr": None,
+            "vol_shape": (4, 4, 3),
+            "add_bzero": True,
+        },
+    ],
+    indirect=True,
+)
 @pytest.mark.parametrize("index", (4, 9))
 @pytest.mark.parametrize("use_mask", (False, True))
 def test_dki_parallel_matches_serial(multi_shell_test_data, index, use_mask):

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -1070,7 +1070,7 @@ def test_serial_fit_typeerror_reraises(multi_shell_test_data, monkeypatch):
 
     class _RaisingDKIModel(_NFDKIModel):
         def fit(self, data, *, mask=None, **kwargs):
-            raise TypeError("boom")
+            raise TypeError("mock type error")
 
     dataset, _, _, _ = setup_multi_shell_fit_predict_data(
         multi_shell_test_data, ignore_bzero=False, use_mask=False
@@ -1079,7 +1079,7 @@ def test_serial_fit_typeerror_reraises(multi_shell_test_data, monkeypatch):
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
-        with pytest.raises(TypeError, match="boom"):
+        with pytest.raises(TypeError, match="mock type error"):
             model.DKIModel(dataset).fit_predict(4, n_jobs=1)
 
 

--- a/test/test_model_dmri.py
+++ b/test/test_model_dmri.py
@@ -42,6 +42,7 @@ from nifreeze.data.dmri.utils import (
 )
 from nifreeze.model._dipy import GaussianProcessModel
 from nifreeze.model.base import MASK_ABSENCE_WARN_MSG
+from nifreeze.model.dki import DiffusionKurtosisModel as _NFDKIModel
 from nifreeze.testing import simulations as _sim
 
 B_MATRIX = np.array(
@@ -1010,22 +1011,19 @@ def test_dki_model_predict(multi_shell_test_data, index, ignore_bzero, use_mask)
 def test_dki_dispatches_dipy_native_parallel(multi_shell_test_data, monkeypatch):
     """``n_jobs > 1`` must switch DKI onto DIPY's parallel ``multi_voxel_fit``.
 
-    The switch is observable as the ``DiffusionKurtosisModel`` being constructed
-    with ``engine="joblib", n_jobs=N``, which routes ``multi_fit`` through the
-    parallel branch of DIPY's ``multi_voxel_fit`` decorator. With ``n_jobs == 1``
-    no ``engine`` is passed and DKI fits serially. See gh-442.
+    NiFreeze's DKI adapter exposes a decorated-``fit`` interface, so the switch is
+    observable as ``engine="joblib", n_jobs=N`` being passed at **fit** time
+    (routing ``multi_fit`` through the parallel branch of DIPY's
+    ``multi_voxel_fit`` decorator). With ``n_jobs == 1`` no ``engine`` is passed
+    and DKI fits serially. See gh-442.
     """
 
-    class _SpyDKIModel(dki.DiffusionKurtosisModel):
-        calls: list[dict] = []
+    class _SpyDKIModel(_NFDKIModel):
+        fit_calls: list[dict] = []
 
-        def __init__(self, gtab, *args, **kwargs):
-            type(self).calls.append(dict(kwargs))
-            # Strip the orchestration kwargs so the (serial) real fit runs and
-            # the assertion stays a pure dispatch contract.
-            for key in ("engine", "n_jobs", "vox_per_chunk", "verbose"):
-                kwargs.pop(key, None)
-            super().__init__(gtab, *args, **kwargs)
+        def fit(self, data, *, mask=None, **kwargs):
+            type(self).fit_calls.append(dict(kwargs))
+            return super().fit(data, mask=mask, **kwargs)
 
     dataset, _, _, _ = setup_multi_shell_fit_predict_data(
         multi_shell_test_data, ignore_bzero=False, use_mask=False
@@ -1033,30 +1031,23 @@ def test_dki_dispatches_dipy_native_parallel(multi_shell_test_data, monkeypatch)
 
     # NiFreeze builds the model via ``import_module(...).DiffusionKurtosisModel``,
     # so patching the module attribute intercepts construction inside ``_fit``.
-    monkeypatch.setattr("dipy.reconst.dki.DiffusionKurtosisModel", _SpyDKIModel)
+    monkeypatch.setattr("nifreeze.model.dki.DiffusionKurtosisModel", _SpyDKIModel)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
 
-        _SpyDKIModel.calls = []
+        _SpyDKIModel.fit_calls = []
         model.DKIModel(dataset).fit_predict(4, n_jobs=1)
-        assert _SpyDKIModel.calls
-        assert all("engine" not in call for call in _SpyDKIModel.calls)
+        assert _SpyDKIModel.fit_calls
+        assert all("engine" not in call for call in _SpyDKIModel.fit_calls)
 
-        # With n_jobs > 1, an engine argument is passed to DIPY's DKI model
-        _SpyDKIModel.calls = []
+        # With n_jobs > 1, engine/n_jobs are passed to DKI's ``fit``.
+        _SpyDKIModel.fit_calls = []
         model.DKIModel(dataset).fit_predict(4, n_jobs=4)
         assert any(
             call.get("engine") == "joblib" and call.get("n_jobs") == 4
-            for call in _SpyDKIModel.calls
+            for call in _SpyDKIModel.fit_calls
         )
-
-    # The DIPY-native engine is a per-model capability: only multi_voxel_fit
-    # models declare it. DTI/GQI/GP keep the data-chunking path.
-    assert model.dmri.DKIModel._multivoxel_engine is True
-    assert model.dmri.DTIModel._multivoxel_engine is False
-    assert model.dmri.GQIModel._multivoxel_engine is False
-    assert model.dmri.GPModel._multivoxel_engine is False
 
 
 @pytest.mark.parametrize(
@@ -1176,6 +1167,44 @@ def test_dti_parallel_matches_serial(single_shell_test_data, index):
         )
         serial = model.DTIModel(dataset).fit_predict(index, n_jobs=1)
         parallel = model.DTIModel(dataset).fit_predict(index, n_jobs=2)
+
+    assert serial is not None
+    assert parallel is not None
+    assert serial.shape == parallel.shape
+    assert np.allclose(serial, parallel, rtol=1e-5, atol=1e-6, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    "single_shell_test_data",
+    [
+        {
+            "bval_shell": 1000,
+            "S0": 100,
+            "evals": (0.0015, 0.0003, 0.0003),
+            "hsph_dirs": 30,
+            "snr": None,
+            "vol_shape": (4, 4, 3),
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("index", (4, 9))
+def test_gqi_fit_predict(single_shell_test_data, index):
+    """GQI (a NiFreeze-custom model) parallelizes by chunking the data.
+
+    Its ``fit`` does not accept the DIPY-native ``engine`` kwargs, so ``_fit``
+    must fall back to the data-chunking path. The chunked (``n_jobs=2``) result
+    must match the serial (``n_jobs=1``) path since voxel-wise fitting is
+    independent.
+    """
+    dataset, _, _, _ = setup_single_shell_fit_predict_data(
+        single_shell_test_data, ignore_bzero=False, use_mask=False
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=MASK_ABSENCE_WARN_MSG, category=UserWarning)
+        serial = model.dmri.GQIModel(dataset).fit_predict(index, n_jobs=1)
+        parallel = model.dmri.GQIModel(dataset).fit_predict(index, n_jobs=2)
 
     assert serial is not None
     assert parallel is not None

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -261,7 +261,7 @@ def test_parsed_dwimodel_instatiation(setup_random_dwi_data, datadir, models):
     elif models == "dki":
         assert (
             DKIModel(dataset, **model_kwargs)._model_class
-            == "dipy.reconst.dki.DiffusionKurtosisModel"
+            == "nifreeze.model.dki.DiffusionKurtosisModel"
         )
 
 


### PR DESCRIPTION
DKI is the only method where fit is not decorated, and the parallelization parameters are passed at `__init__` time.