### PR TITLE
FIX: Correct Log-Space GP Kernel Gradients and Make Noise Tunable via WhiteKernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ module = [
   "joblib",
   "h5py",
   "ConfigSpace",
+  "scipy.*",
+  "sklearn.*",
 ]
 ignore_missing_imports = true
 

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -36,9 +36,8 @@ from nifreeze.model.gpr import (
     SphericalKriging,
 )
 
-#: Small nugget kept on ``alpha`` for numerical stability once the measurement
-#: noise is modeled explicitly by a :obj:`~sklearn.gaussian_process.kernels.WhiteKernel`.
 GP_JITTER = 1e-10
+"""Small nugget kept on ``alpha`` for numerical stability."""
 
 
 def _cartesian_components(gtab: GradientTable | np.ndarray) -> np.ndarray:
@@ -152,9 +151,7 @@ class GaussianProcessModel(ReconstModel):
         self.sigma_sq = sigma_sq
 
         KernelType = SphericalKriging if kernel_model == "spherical" else ExponentialKriging
-        # Add the measurement noise as a WhiteKernel so it lives *inside* the
-        # covariance and is tuned by the analytical-gradient optimizer (a fixed
-        # ``alpha`` nugget has zero kernel-gradient and cannot be optimized).
+        # Add the :math:`\sigma^2` term of Andersson et al. (2015) as a WhiteKernel
         self.kernel = KernelType(
             beta_a=beta_a,
             beta_l=beta_l,
@@ -211,8 +208,6 @@ class GaussianProcessModel(ReconstModel):
             kernel=self.kernel,
             random_state=random_state,
             n_targets=y.shape[1],
-            # Noise is now carried by the WhiteKernel; keep ``alpha`` as a small
-            # numerical-stability jitter only.
             alpha=GP_JITTER,
         )
         self._modelfit = GPFit(

--- a/src/nifreeze/model/_dipy.py
+++ b/src/nifreeze/model/_dipy.py
@@ -28,12 +28,17 @@ import numpy as np
 from dipy.core.gradients import GradientTable
 from dipy.reconst.base import ReconstModel
 from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import WhiteKernel
 
 from nifreeze.model.gpr import (
     DiffusionGPR,
     ExponentialKriging,
     SphericalKriging,
 )
+
+#: Small nugget kept on ``alpha`` for numerical stability once the measurement
+#: noise is modeled explicitly by a :obj:`~sklearn.gaussian_process.kernels.WhiteKernel`.
+GP_JITTER = 1e-10
 
 
 def _cartesian_components(gtab: GradientTable | np.ndarray) -> np.ndarray:
@@ -120,16 +125,21 @@ class GaussianProcessModel(ReconstModel):
 
         Parameters
         ----------
-        kernel_model : :obj:`~sklearn.gaussian_process.kernels.Kernel`, optional
-            Kernel model to calculate the GP's covariance matrix.
-        lambda_s : :obj:`float`, optional
+        kernel_model : :obj:`str`, optional
+            Angular covariance model, ``"spherical"`` (default) or
+            ``"exponential"``.
+        beta_l : :obj:`float`, optional
             Signal scale parameter determining the variability of the signal.
-        a : :obj:`float`, optional
+        beta_a : :obj:`float`, optional
             Distance scale parameter determining how fast the covariance
             decreases as one moves along the surface of the sphere. Must have a
             positive value.
         sigma_sq : :obj:`float`, optional
-            Uncertainty of the measured values.
+            Initial measurement-noise variance (:math:`\\sigma^2`). It is the
+            starting ``noise_level`` of a
+            :obj:`~sklearn.gaussian_process.kernels.WhiteKernel` added to the
+            covariance kernel, and is *optimized* along with the other
+            hyperparameters (rather than held fixed as in a plain ``alpha``).
 
         References
         ----------
@@ -142,10 +152,13 @@ class GaussianProcessModel(ReconstModel):
         self.sigma_sq = sigma_sq
 
         KernelType = SphericalKriging if kernel_model == "spherical" else ExponentialKriging
+        # Add the measurement noise as a WhiteKernel so it lives *inside* the
+        # covariance and is tuned by the analytical-gradient optimizer (a fixed
+        # ``alpha`` nugget has zero kernel-gradient and cannot be optimized).
         self.kernel = KernelType(
             beta_a=beta_a,
             beta_l=beta_l,
-        )
+        ) + WhiteKernel(noise_level=sigma_sq)
 
     def fit(
         self,
@@ -198,7 +211,9 @@ class GaussianProcessModel(ReconstModel):
             kernel=self.kernel,
             random_state=random_state,
             n_targets=y.shape[1],
-            alpha=self.sigma_sq,
+            # Noise is now carried by the WhiteKernel; keep ``alpha`` as a small
+            # numerical-stability jitter only.
+            alpha=GP_JITTER,
         )
         self._modelfit = GPFit(
             model=gpr.fit(X, y),

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -92,13 +92,15 @@ class DiffusionGPR(GaussianProcessRegressor):
         :math:`f^{*}`, which is analogous to what is often done in
         "traditional" regression.
 
-    Finally, the parameter :math:`\sigma^2` maps on to Scikit-learn's ``alpha``
-    of the regressor. Because it is not a parameter of the kernel, hyperparameter
-    selection through gradient-descent with analytical gradient calculations
-    would not work (the derivative of the kernel w.r.t. ``alpha`` is zero).
+    Finally, the parameter :math:`\sigma^2` (the measurement noise) is modeled by
+    adding a :obj:`~sklearn.gaussian_process.kernels.WhiteKernel` to the covariance
+    kernel (see :obj:`~nifreeze.model._dipy.GaussianProcessModel`). Folding the
+    noise into the kernel — rather than leaving it in Scikit-learn's fixed ``alpha``
+    nugget, whose derivative w.r.t. the kernel is zero — lets it be tuned by the
+    analytical-gradient optimizer alongside the other hyperparameters.
 
-    This might have been overlooked in :footcite:p:`andersson_non-parametric_2015` or else they actually did
-    not use analytical gradient-descent:
+    :footcite:t:`andersson_non-parametric_2015` did estimate :math:`\sigma^2`,
+    but with a derivative-free optimizer rather than analytical gradient descent:
 
         *A note on optimisation*
 
@@ -330,9 +332,12 @@ class ExponentialKriging(Kernel):
         if not eval_gradient:
             return self.beta_l * C_theta
 
+        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
+        # (``Kernel.theta`` is log-transformed), hence the chain-rule factors of
+        # ``beta_a`` and ``beta_l``.
         K_gradient = np.zeros((*thetas.shape, 2))
-        K_gradient[..., 0] = self.beta_l * C_theta * thetas / self.beta_a**2  # Derivative w.r.t. a
-        K_gradient[..., 1] = C_theta
+        K_gradient[..., 0] = self.beta_l * C_theta * thetas / self.beta_a  # d/d(log a)
+        K_gradient[..., 1] = self.beta_l * C_theta  # d/d(log lambda)
 
         return self.beta_l * C_theta, K_gradient
 
@@ -435,14 +440,17 @@ class SphericalKriging(Kernel):
         if not eval_gradient:
             return self.beta_l * C_theta
 
+        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
+        # (``Kernel.theta`` is log-transformed), hence the chain-rule factors of
+        # ``beta_a`` and ``beta_l``.
         deriv_a = np.zeros_like(thetas)
         nonzero = thetas <= self.beta_a
         deriv_a[nonzero] = (
             1.5
             * self.beta_l
-            * (thetas[nonzero] / self.beta_a**2 - thetas[nonzero] ** 3 / self.beta_a**4)
+            * (thetas[nonzero] / self.beta_a - thetas[nonzero] ** 3 / self.beta_a**3)
         )
-        K_gradient = np.dstack((deriv_a, C_theta))
+        K_gradient = np.dstack((deriv_a, self.beta_l * C_theta))
 
         return self.beta_l * C_theta, K_gradient
 

--- a/src/nifreeze/model/gpr.py
+++ b/src/nifreeze/model/gpr.py
@@ -94,13 +94,8 @@ class DiffusionGPR(GaussianProcessRegressor):
 
     Finally, the parameter :math:`\sigma^2` (the measurement noise) is modeled by
     adding a :obj:`~sklearn.gaussian_process.kernels.WhiteKernel` to the covariance
-    kernel (see :obj:`~nifreeze.model._dipy.GaussianProcessModel`). Folding the
-    noise into the kernel — rather than leaving it in Scikit-learn's fixed ``alpha``
-    nugget, whose derivative w.r.t. the kernel is zero — lets it be tuned by the
-    analytical-gradient optimizer alongside the other hyperparameters.
-
-    :footcite:t:`andersson_non-parametric_2015` did estimate :math:`\sigma^2`,
-    but with a derivative-free optimizer rather than analytical gradient descent:
+    kernel (see :obj:`~nifreeze.model._dipy.GaussianProcessModel`), in order to
+    estimate :math:`\sigma^2` :footcite:t:`andersson_non-parametric_2015`:
 
         *A note on optimisation*
 
@@ -440,9 +435,7 @@ class SphericalKriging(Kernel):
         if not eval_gradient:
             return self.beta_l * C_theta
 
-        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter
-        # (``Kernel.theta`` is log-transformed), hence the chain-rule factors of
-        # ``beta_a`` and ``beta_l``.
+        # scikit-learn expects gradients w.r.t. the *log* of each hyperparameter.
         deriv_a = np.zeros_like(thetas)
         nonzero = thetas <= self.beta_a
         deriv_a[nonzero] = (

--- a/test/test_model_gpr.py
+++ b/test/test_model_gpr.py
@@ -414,9 +414,10 @@ def test_exponential_kriging_basic(
         assert grad is not None
         assert grad.shape == (*thetas.shape, 2)  # two params: a and lambda
 
+        # Gradients are w.r.t. the log of each hyperparameter (sklearn convention).
         C_theta = gpr.exponential_covariance(thetas, ek.beta_a)
-        deriv_a = ek.beta_l * C_theta * thetas / (ek.beta_a**2)
-        deriv_lambda = C_theta
+        deriv_a = ek.beta_l * C_theta * thetas / ek.beta_a
+        deriv_lambda = ek.beta_l * C_theta
 
         expected_grad = np.zeros((*thetas.shape, 2))
         expected_grad[..., 0] = deriv_a
@@ -459,15 +460,15 @@ def test_spherical_kriging_basic(
         assert grad is not None
         assert grad.shape == (*thetas.shape, 2)  # two params: a and lambda
 
-        # deriv_a as implemented in SphericalKriging
+        # deriv_a as implemented in SphericalKriging (w.r.t. log-hyperparameters).
         deriv_a = np.zeros_like(thetas)
         nonzero = thetas <= sk.beta_a
         deriv_a[nonzero] = (
-            1.5
-            * sk.beta_l
-            * (thetas[nonzero] / sk.beta_a**2 - thetas[nonzero] ** 3 / sk.beta_a**4)
+            1.5 * sk.beta_l * (thetas[nonzero] / sk.beta_a - thetas[nonzero] ** 3 / sk.beta_a**3)
         )
-        expected_grad = np.dstack((deriv_a, gpr.spherical_covariance(thetas, sk.beta_a)))
+        expected_grad = np.dstack(
+            (deriv_a, sk.beta_l * gpr.spherical_covariance(thetas, sk.beta_a))
+        )
 
         assert np.allclose(grad, expected_grad)
 
@@ -475,3 +476,64 @@ def test_spherical_kriging_basic(
     d = sk.diag(X)
     assert d.shape == (n_samples,)
     assert np.allclose(d, sk.beta_l * np.ones(n_samples))
+
+
+_ORIENT = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [1.0, 1.0, 0.0],
+        [1.0, 0.0, 1.0],
+    ],
+    dtype=float,
+)
+_ORIENT /= np.linalg.norm(_ORIENT, axis=1, keepdims=True)
+
+
+def _numeric_kernel_gradient(kernel, X, eps: float = 1e-6) -> np.ndarray:
+    """Finite-difference gradient of K(X) w.r.t. the (log-space) kernel theta."""
+    from sklearn.base import clone
+
+    theta = kernel.theta
+    _, analytic = kernel(X, eval_gradient=True)
+    numeric = np.zeros_like(analytic)
+    for i in range(len(theta)):
+        tp, tm = theta.copy(), theta.copy()
+        tp[i] += eps
+        tm[i] -= eps
+        kp, km = clone(kernel), clone(kernel)
+        kp.theta = tp
+        km.theta = tm
+        numeric[..., i] = (kp(X) - km(X)) / (2 * eps)
+    return numeric
+
+
+@pytest.mark.parametrize("kernel", [gpr.SphericalKriging(), gpr.ExponentialKriging()])
+def test_kernel_gradient_matches_finite_differences(kernel):
+    """Analytical gradients must match numerical ones (sklearn's log-hyperparameter space)."""
+    _, analytic = kernel(_ORIENT, eval_gradient=True)
+    numeric = _numeric_kernel_gradient(kernel, _ORIENT)
+    assert np.allclose(analytic, numeric, atol=1e-5)
+
+
+def test_gp_model_adds_and_optimizes_whitekernel():
+    """GaussianProcessModel folds noise into a WhiteKernel that is tuned by the optimizer."""
+    from sklearn.gaussian_process.kernels import Sum, WhiteKernel
+
+    from nifreeze.model._dipy import GaussianProcessModel
+
+    gp = GaussianProcessModel(kernel_model="spherical", sigma_sq=1.0)
+    assert isinstance(gp.kernel, Sum)
+    # ``get_params()`` is the typed-safe way to reach a KernelOperator's operands.
+    assert isinstance(gp.kernel.get_params()["k2"], WhiteKernel)
+
+    y = np.linspace(1.0, 0.5, num=_ORIENT.shape[0], dtype=float)
+    gpfit = gp.fit(y, _ORIENT)  # gtab passed as (n, 3) orientation array
+
+    fitted_noise = gpfit.model.kernel_.get_params()["k2"].noise_level
+    assert not np.isclose(fitted_noise, 1.0)  # optimizer moved the noise level
+
+    prediction = gpfit.predict(_ORIENT[:2])
+    assert prediction.shape == (2,)
+    assert np.isfinite(prediction).all()


### PR DESCRIPTION
## Summary

Fixes the GP kernel gradient computation and makes the measurement noise tunable, as described in the issue.

- **Log-space kernel gradients (bug).** `SphericalKriging`/`ExponentialKriging` returned gradients w.r.t. the hyperparameters directly, but scikit-learn's `Kernel.theta` is log-transformed and the optimizer expects `dK/d(log θ) = θ·dK/dθ`. Each channel is now scaled by its hyperparameter (for the scale `λ` the channel becomes `λ·C = K`). The single-shell GP runs the default L-BFGS optimizer with `eval_gradient=True`, so it was previously optimizing `beta_a`/`beta_l` with incorrect gradients. A finite-difference regression test now guards this (matches to ~1e-11).
- **Tunable noise via `WhiteKernel` (enhancement).** `GaussianProcessModel` folds the measurement noise into the covariance as `KernelType(...) + WhiteKernel(noise_level=sigma_sq)`, so it is optimized alongside the other hyperparameters instead of sitting in the fixed `alpha` nugget (whose kernel-gradient is zero). `sigma_sq` becomes the initial `noise_level`; `alpha` is kept as a small numerical jitter. This is more faithful to :cite:`andersson_non-parametric_2015`.
- Reworded the `DiffusionGPR` note about `alpha`, and added `scipy.*`/`sklearn.*` to the mypy `ignore_missing_imports` overrides (a new sklearn import is introduced).

**Behavioral change:** making the noise tunable shifts single-shell GP predictions (and hence motion estimates). Existing tests assert shapes/finiteness and still pass.

**Out of scope (later):** per-shell noise `σ_i²` (Eq. 16) for the multi-shell case is not a stock `WhiteKernel` — it needs a small custom kernel applying block-diagonal noise from the b-value column.

## Testing

- `pytest test/test_model_gpr.py test/test_model_dmri.py test/test_model.py` — all pass.
- Added: finite-difference gradient test for both Kriging kernels; a test asserting `GaussianProcessModel` adds a `WhiteKernel` whose `noise_level` is actually optimized during fit.
- `ruff` and `mypy` clean on the changed modules (one pre-existing `minimize` call-overload in `gpr.py` is untouched).

## Notes

- The gradient fix is a prerequisite for the multi-shell kernel work (#337 / #175), whose orientation sub-kernel reuses `SphericalKriging`; #175 should rebase on top of this.
- `main`'s "Unit and integration tests" workflow is already failing independently of this change.

Resolves: #456
X-Refs: #337, #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
