### PR TITLE
FIX: Narrow `CellResult.reason` Before Membership Test

### DIFF
--- a/test/test_gallery.py
+++ b/test/test_gallery.py
@@ -366,6 +366,7 @@ def test_gallery_collect_reconciles_missing_cells(tmp_path):
     assert len(manifest.cells) == 2
     dki = [c for c in manifest.cells if c.model == "dki"][0]
     assert dki.status == "error"
+    assert dki.reason is not None
     assert "no output produced" in dki.reason
     # The cell that did report is untouched.
     assert [c for c in manifest.cells if c.model == "gqi"][0].status == STATUS_RAN


### PR DESCRIPTION
`mypy .` fails on `main`, breaking the `typecheck` tox env:

```
test/test_gallery.py:369: error: Unsupported right operand type for in ("str | None")  [operator]
Found 1 error in 1 file (checked 95 source files)
```

`CellResult.reason` is `str | None`, so testing membership against it directly is
unsafe and mypy rejects it. Assert the reason is set before the membership test,
which also tightens the assertion.

The line came from #462; merging #463 is simply when `mypy .` next ran over
`main`. It slipped through because the branch was type-checked with a narrower
invocation than CI's `mypy .`, which covers the tests too.

Verified: local `mypy .` reproduces the error when the fix is reverted and is
clean with it applied; `test/test_gallery.py` passes (25 tests) and ruff is clean.

X-Refs: #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5uCFwTRTQuPmNJXQJW6EP