### PR TITLE
DOC: Miscellaneous syntax highlighting fixes

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -11,7 +11,7 @@ Airspeed Velocity manages building and Python environments by itself,
 unless told otherwise.
 To run the benchmarks, you do not need to install
 a development version of *NiFreeze* on your current
-*Python* environment.
+Python environment.
 
 To run all benchmarks for the latest commit, navigate to *NiFreeze*'s root
 ``benchmarks`` directory and execute::

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -241,14 +241,16 @@ Contributing to NiFreeze
 Set up for Development
 ----------------------
 
-Install the appropriate modules::
+Install the appropriate modules:
 
-   .. code-block:: bash
+.. code-block:: bash
+
    pip install .[test, doc, style, contributing]
 
-Download data from OSF, OpenNeuro, etc.::
+Download data from OSF, OpenNeuro, etc.:
 
-   .. code-block:: bash
+.. code-block:: bash
+
    download
 
 Typechecking, spellchecking, style, doc

--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -2,9 +2,9 @@
 
 .. _gallery:
 
-===========================
+==================
 Prediction gallery
-===========================
+==================
 This gallery shows *predicted* diffusion volumes produced by *NiFreeze*'s models
 on several real datasets spanning the acquisition-scheme spectrum — a simple,
 legacy DTI dataset, a single-shell HARDI dataset, a multi-shell dataset, and a

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Make sure all of *nifreeze*' `External Dependencies`_ are installed.
 
 On a functional Python 3.10 (or above) environment with ``pip`` installed,
-*nifreeze* can be installed using the usual `pip install` command::
+*nifreeze* can be installed using the usual ``pip install`` command::
 
     python -m pip install nifreeze
 


### PR DESCRIPTION
- DOC: Use double backticks for rST verbatim syntax highlighting
- DOC: Do not highlight Python
- DOC: Make the section title punctuation length match the title length
- DOC: Fix code-block directive indentation