### PR TITLE
STY: Prefer using the `load_api` util for consistent volume loading

### DIFF
--- a/docs/sphinxext/gallery/datasets.py
+++ b/docs/sphinxext/gallery/datasets.py
@@ -288,11 +288,11 @@ def _load_dwi(
     concatenated along the volume axis (used for datasets that store shells as
     separate files, e.g. ds003138).
     """
-    from typing import cast
 
-    import nibabel as nb
     from dipy.io import read_bvals_bvecs
     from nibabel.spatialimages import SpatialImage
+
+    from nifreeze.utils.ndimage import load_api
 
     _get(ds_path, [f for triple in triples for f in triple])
 
@@ -301,7 +301,7 @@ def _load_dwi(
     bvecs_list: list[np.ndarray] = []
     affine: np.ndarray | None = None
     for dwi_file, bval_file, bvec_file in triples:
-        img = cast(SpatialImage, nb.load(str(dwi_file)))
+        img = load_api(dwi_file, SpatialImage)
         affine = img.affine
         data_list.append(np.asarray(img.dataobj, dtype=np.float32))
         bvals, bvecs = read_bvals_bvecs(str(bval_file), str(bvec_file))

--- a/test/test_model_gqi.py
+++ b/test/test_model_gqi.py
@@ -504,18 +504,18 @@ def test_gqi_lovo_prediction_stanford_hardi(method):
     signal predictor (oscillatory, ill-conditioned reconstruction kernel), which
     is why ``"standard"`` is the NiFreeze default.
     """
-    from typing import cast
 
-    import nibabel as nb
     from dipy.io.gradients import read_bvals_bvecs
     from nibabel.spatialimages import SpatialImage
+
+    from nifreeze.utils.ndimage import load_api
 
     try:
         fdwi, fbval, fbvec = get_fnames(name="stanford_hardi")
     except Exception as exc:  # pragma: no cover - network/cache guard
         pytest.skip(f"Stanford HARDI not available: {exc}")
 
-    img = cast(SpatialImage, nb.load(fdwi))
+    img = load_api(fdwi, SpatialImage)
     # Crop a small central slab to keep the test fast.
     sl = (slice(28, 52), slice(50, 74), slice(35, 40))
     dataobj = np.asarray(img.dataobj[sl].astype(np.float32))


### PR DESCRIPTION
Prefer using the `load_api` util for consistent volume loading.