### PR TITLE
STY: Fix miscellaneous style errors across wiki pages

### DIFF
--- a/.wiki/pages/entity/tool-dipy-reconst-contract.md
+++ b/.wiki/pages/entity/tool-dipy-reconst-contract.md
@@ -19,12 +19,13 @@ page caches the contract at DIPY commit `2ecd3655`. Facet of [[tool-dipy]].
 
 ```python
 class ReconstModel:
-    def __init__(self, gtab): ...                    # stores self.gtab = gtab
-    def fit(self, data, *, mask=None, **kwargs):     # concrete stub -> ReconstFit(self, data)
+    def __init__(self, gtab): ...  # stores self.gtab = gtab
+    def fit(self, data, *, mask=None, **kwargs):  # concrete stub -> ReconstFit(self, data)
         ...
 
+
 class ReconstFit:
-    def __init__(self, model, data): ...             # self.model, self.data
+    def __init__(self, model, data): ...  # self.model, self.data
 ```
 
 Two facts about this pinned version matter:
@@ -42,9 +43,9 @@ Two facts about this pinned version matter:
 Across DIPY's models the shape is:
 
 ```python
-model = SomeModel(gtab, **model_kwargs)   # construct from a gradient table
-fit   = model.fit(data, mask=None)        # fit to (voxels × directions) signal
-pred  = fit.predict(gtab_new, S0=...)     # predict signal at new directions
+model = SomeModel(gtab, **model_kwargs)  # construct from a gradient table
+fit = model.fit(data, mask=None)  # fit to (voxels × directions) signal
+pred = fit.predict(gtab_new, S0=...)  # predict signal at new directions
 ```
 
 nifreeze's `BaseDWIModel` treats this as the uniform interface for every

--- a/.wiki/pages/entity/tool-dipy-sims-voxel.md
+++ b/.wiki/pages/entity/tool-dipy-sims-voxel.md
@@ -52,7 +52,7 @@ multi_tensor(gtab, mevals, *, S0=1.0, angles=((0, 0), (90, 0)),
 ## `all_tensor_evecs`
 
 ```python
-all_tensor_evecs(e0)   # -> (3, 3) eigenvector frame (columns)
+all_tensor_evecs(e0)  # -> (3, 3) eigenvector frame (columns)
 ```
 
 - Given a principal axis `e0` (3,), builds an orthonormal eigenvector frame by


### PR DESCRIPTION
Fix miscellaneous style errors across wiki pages:
- Allow two whitespaces only for inline comments.
- Use two empty lines to separate class definitions.

Fixes `ruff` complaints on wiki pages that have started appearing on 23.07.2026, e.g.
https://github.com/nipreps/nifreeze/actions/runs/30037354588/job/89308542119?pr=471#step:5:58