### PR TITLE
MNT: Require Python greater or equal to 3.12

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ github.event_name == 'schedule' && fromJson('["3.10", "3.11", "3.12", "3.13"]') || fromJson('["3.12"]') }}
+        python-version: ${{ github.event_name == 'schedule' && fromJson('["3.12", "3.13", "3.14"]') || fromJson('["3.12"]') }}
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
     needs: ['cache-test-data']
     strategy:
       matrix:
-        python-version: ${{ github.event_name == 'schedule' && fromJson('["3.10", "3.11", "3.12", "3.13"]') || fromJson('["3.12"]') }}
+        python-version: ${{ github.event_name == 'schedule' && fromJson('["3.12", "3.13", "3.14", "3.15"]') || fromJson('["3.12"]') }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -21,7 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.12"
 # dependencies = [
 #     "click",
 #     "fuzzywuzzy",

--- a/.maint/update_description.py
+++ b/.maint/update_description.py
@@ -22,7 +22,7 @@
 #
 
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.12"
 # dependencies = [
 #     "click",
 #     "toml",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ python -m ruff check --fix <files>   # lint and auto-fix
 python -m run ruff format <files>        # reformat
 ```
 
-Ruff config: line-length 99, target Python 3.10, rules: F, E, C, W, B, I, ICN. Import convention: `nibabel` aliased as `nb`.
+Ruff config: line-length 99, target Python 3.12, rules: F, E, C, W, B, I, ICN. Import convention: `nibabel` aliased as `nb`.
 
 ### Type checking
 ```bash
@@ -127,6 +127,6 @@ Three-layer design: **Data → Model → Estimator**
 ## Key Conventions
 
 - Calendar-based versioning (nipreps-calver) via hatch-vcs
-- Python 3.10+ required; code targets `py310`
+- Python 3.12+ required; code targets `py312`
 - Uses `attrs` for data classes (not dataclasses)
 - `nibabel` is always imported as `nb`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 ============
 Make sure all of *nifreeze*' `External Dependencies`_ are installed.
 
-On a functional Python 3.10 (or above) environment with ``pip`` installed,
+On a functional Python 3.12 (or above) environment with ``pip`` installed,
 *nifreeze* can be installed using the usual ``pip install`` command::
 
     python -m pip install nifreeze

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,23 +12,22 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Image Recognition",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 license = "Apache-2.0"
 license-files = ["LICEN[CS]E*"]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
   "attrs>=24.1.0",
   "dipy @ git+https://github.com/dipy/dipy.git@2ecd3655",
   "joblib",
-  "matplotlib>=2.2.0,<3.11; python_version == '3.10'",
-  "matplotlib>=3.11; python_version > '3.10'",
+  "matplotlib>=3.11",
   "nipype>=1.11.0,<2.0",
   "nitransforms>=25.0.0",
   "nireports",
-  "numpy>=1.21.3,<2.4.0",
+  "numpy>=1.26.0,<2.4.0",
   "nest-asyncio>=1.5.1",
   "scikit-image>=0.15.0",
   "scikit-learn>=1.3.0",
@@ -175,7 +174,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 99
-target-version = "py310"
+target-version = "py312"
 exclude = [
   ".eggs",
   ".git",

--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -286,13 +286,13 @@ def test_getitem_volume_index(random_dataset: BaseDataset):
     By default, motion_affines is None, so we expect to get None for the affine.
     """
     # Single volume  # Note that the type ignore can be removed once we can use *Ts
-    volume0, aff0 = random_dataset[0]  # type: ignore[misc]  # PY310
+    volume0, aff0 = random_dataset[0]
     assert volume0.shape == (32, 32, 32)
     # No transforms have been applied yet, so there's no motion_affines array
     assert aff0 is None
 
     # Slice of volumes
-    volume_slice, aff_slice = random_dataset[2:4]  # type: ignore[misc]  # PY310
+    volume_slice, aff_slice = random_dataset[2:4]
     assert volume_slice.shape == (32, 32, 32, 2)
     assert aff_slice is None
 
@@ -309,7 +309,7 @@ def test_set_transform(random_dataset: BaseDataset):
     random_dataset.set_transform(idx, affine)
 
     # Data shouldn't have changed (since transform is identity).
-    volume0, aff0 = random_dataset[idx]  # type: ignore[misc]  # PY310
+    volume0, aff0 = random_dataset[idx]
     assert np.allclose(data_before, volume0)
 
     # motion_affines should be created and match the transform matrix.

--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -286,13 +286,13 @@ def test_getitem_volume_index(random_dataset: BaseDataset):
     By default, motion_affines is None, so we expect to get None for the affine.
     """
     # Single volume  # Note that the type ignore can be removed once we can use *Ts
-    volume0, aff0 = random_dataset[0]
+    volume0, aff0, *_ = random_dataset[0]
     assert volume0.shape == (32, 32, 32)
     # No transforms have been applied yet, so there's no motion_affines array
     assert aff0 is None
 
     # Slice of volumes
-    volume_slice, aff_slice = random_dataset[2:4]
+    volume_slice, aff_slice, *_ = random_dataset[2:4]
     assert volume_slice.shape == (32, 32, 32, 2)
     assert aff_slice is None
 
@@ -309,7 +309,7 @@ def test_set_transform(random_dataset: BaseDataset):
     random_dataset.set_transform(idx, affine)
 
     # Data shouldn't have changed (since transform is identity).
-    volume0, aff0 = random_dataset[idx]
+    volume0, aff0, *_ = random_dataset[idx]
     assert np.allclose(data_before, volume0)
 
     # motion_affines should be created and match the transform matrix.

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ skip_missing_interpreters = true
 # Configuration that allows us to split tests across GitHub runners effectively
 [gh-actions]
 python =
-  3.10: py310
-  3.11: py311
   3.12: py312
   3.13: py313
+  3.14: py314
+  3.15: py315
 
 [testenv]
 description = Pytest with coverage


### PR DESCRIPTION
Require Python greater or equal to 3.12:
- Support for Python 3.10 will end in 2 months (EOL 2026-10).
- Commit b4f4f8f required DIPY `HEAD`, which requires Python >= 3.12.
- Update the minimum required versions for the dependencies accordingly.

Add Python 3.14 and 3.15 to the matrix of Python versions in CI testing workflow; add Python 3.14 to packaging CI workflow as Python 3.15 is still in pre-release status.