### PR TITLE
MNT: Bump miscellaneous GitHub action versions

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -85,7 +85,7 @@ jobs:
           git config --global user.email "nipreps@gmail.com"
           git config --global user.name "nipreps-bot"
       - name: Cache the cropped dataset (cross-run)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # The sidecar must travel with the .h5: without it the fit jobs would
           # fall back to resolving provenance from the (absent) datalad clone.
@@ -132,7 +132,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[gallery]
       - name: Download dataset
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gallery-data-${{ matrix.cell.dataset }}
           path: ${{ env.NIFREEZE_GALLERY_H5DIR }}
@@ -191,12 +191,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[gallery]
       - name: Download cell outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: gallery-cell-*
           path: gallery-staging
       - name: Download coverage fragments
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: gallery-cov-*
           path: gallery-cov
@@ -244,7 +244,7 @@ jobs:
           path: docs/gallery
       - name: Upload coverage to Codecov
         if: hashFiles('coverage-gallery.xml') != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage-gallery.xml
           flags: gallery

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -38,7 +38,7 @@ jobs:
       attestations: write
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: dist
@@ -58,7 +58,7 @@ jobs:
       attestations: write
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
Bump miscellaneous GitHub action versions in workflows. Increases consistency across versions in workflows, and prevent `Node.js` 20 deprecation warnings, e.g.
```
Node.js 20 is deprecated. The following actions target Node.js 20 but
are being forced to run on Node.js 24:
actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea. For more
information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

raised for example in:
https://github.com/nipreps/nifreeze/actions/runs/30224054429