### PR TITLE
STY: Fix miscellaneours style issues

### DIFF
--- a/src/nifreeze/data/dmri/base.py
+++ b/src/nifreeze/data/dmri/base.py
@@ -163,11 +163,13 @@ class DWI(BaseDataset[np.ndarray]):
         # no bzero attribute was provided; warn the user if both the DWI
         # contained b0 values and the bzero attribute was provided
         if b0_num > 0 and self.bzero is None:
-            warn(DWI_B0_MULTIPLE_VOLUMES_WARN_MSG, UserWarning) if b0_num > 1 else None
+            warn(
+                DWI_B0_MULTIPLE_VOLUMES_WARN_MSG, UserWarning, stacklevel=2
+            ) if b0_num > 1 else None
             bzeros = self.dataobj[..., b0_mask]
             bzeros = bzeros.squeeze(axis=-1) if bzeros.shape[-1] == 1 else bzeros
         elif b0_num > 0 and self.bzero is not None:
-            warn(DWI_REDUNDANT_B0_WARN_MSG, UserWarning)
+            warn(DWI_REDUNDANT_B0_WARN_MSG, UserWarning, stacklevel=2)
             bzeros = self.bzero
 
         # Set the bzero attribute to the median if necessary

--- a/test/test_data_base.py
+++ b/test/test_data_base.py
@@ -251,7 +251,7 @@ def test_affine_shape_error(setup_random_uniform_ndim_data, size):
 def test_brainmask_volume_mismatch_error(request, setup_random_uniform_spatial_data):
     data, affine = setup_random_uniform_spatial_data
     data_shape = data.shape[:3]
-    brainmask_size = tuple(map(lambda x: x + 1, data_shape))
+    brainmask_size = tuple(x + 1 for x in data_shape)
     brainmask = request.node.rng.choice([True, False], size=brainmask_size)
     with pytest.raises(
         ValueError,

--- a/test/test_data_pet.py
+++ b/test/test_data_pet.py
@@ -216,10 +216,7 @@ def test_pet_instantiation_attribute_validate_1d_arr_errors(
     rng = request.node.rng
     pet_dataobj, affine, _, _, midframe, total_duration = setup_random_pet_data
 
-    attrs_dict = dict(
-        midframe=midframe,
-        total_duration=total_duration,
-    )
+    attrs_dict = {"midframe": midframe, "total_duration": total_duration}
     _attrs_dict = _add_extra_dim(rng, attr_name, extra_dimensions, transpose, **attrs_dict)
 
     with pytest.raises(
@@ -239,13 +236,11 @@ def test_pet_instantiation_attribute_convert_absence_errors(
 
     n_frames = data.shape[-1]
     # Create a dict with default valid attribute values
-    attrs_dict: dict[str, np.ndarray | float | None] = dict(
-        midframe=np.ones(n_frames, dtype=np.float32),
-        total_duration=1.0,
-    )
-
-    # Override only the attribute under test
-    attrs_dict[attr_name] = None
+    attrs_dict: dict[str, np.ndarray | float | None] = {
+        "midframe": np.ones(n_frames, dtype=np.float32),
+        "total_duration": 1.0,
+        attr_name: None,
+    }
 
     with pytest.raises(ValueError, match=ATTRIBUTE_ABSENCE_ERROR_MSG.format(attribute=attr_name)):
         PET(dataobj=data, affine=affine, **attrs_dict)  # type: ignore[arg-type]
@@ -267,13 +262,11 @@ def test_pet_instantiation_attribute_convert_object_errors(
 
     n_frames = data.shape[-1]
     # Create a dict with some valid attributes
-    attrs_dict = dict(
-        midframe=np.ones(n_frames, dtype=np.float32),
-        total_duration=n_frames + 1,
-    )
-
-    # Override only the attribute under test
-    attrs_dict[attr_name] = value
+    attrs_dict = {
+        "midframe": np.ones(n_frames, dtype=np.float32),
+        "total_duration": n_frames + 1,
+        attr_name: value,
+    }
 
     with pytest.raises(
         TypeError, match=ARRAY_ATTRIBUTE_OBJECT_ERROR_MSG.format(attribute=attr_name)
@@ -293,10 +286,7 @@ def test_pet_instantiation_attribute_vol_mismatch_error(
     pet_dataobj, affine, _, _, midframe, total_duration = setup_random_pet_data
 
     n_frames = int(pet_dataobj.shape[-1])
-    attrs_dict = dict(
-        midframe=midframe,
-        total_duration=total_duration,
-    )
+    attrs_dict = {"midframe": midframe, "total_duration": total_duration}
 
     # Add extra volumes: simply concatenate the last volume
     if extra_volume_count:
@@ -342,10 +332,7 @@ def test_pet_instantiation_attribute_inconsistency_error(
     elif attr_name == "total_duration":
         total_duration = midframe[-1] + excess_value
 
-    attrs_dict = dict(
-        midframe=midframe,
-        total_duration=total_duration,
-    )
+    attrs_dict = {"midframe": midframe, "total_duration": total_duration}
 
     with pytest.raises(
         ValueError,
@@ -431,10 +418,10 @@ def test_from_nii(tmp_path, setup_random_pet_data):
 
     assert isinstance(pet_obj_from_nii, PET)
 
-    attrs_dict: dict[str, np.ndarray | float | None] = dict(
-        midframe=midframe,
-        total_duration=total_duration,
-    )
+    attrs_dict: dict[str, np.ndarray | float | None] = {
+        "midframe": midframe,
+        "total_duration": total_duration,
+    }
 
     # Get all user-defined, named attributes
     attrs_to_check = [


### PR DESCRIPTION
Fix miscellaneous style issues flagged locally by `ruff`. Fixes:
```
Set `stacklevel=2`
```

and
```
Replace `map()` with a generator expression
```

and
```
Unnecessary `dict()` call (rewrite as a literal)
```