### PR TITLE
TST: Check PET B-Spline model order and control point exceptions

### DIFF
--- a/src/nifreeze/model/pet.py
+++ b/src/nifreeze/model/pet.py
@@ -41,6 +41,14 @@ PET_OBJECT_ERROR_MSG = "Dataset MUST be a PET object."
 PET_MIDFRAME_ERROR_MSG = "Dataset MUST have a 'midframe'."
 """PET midframe error message."""
 
+BSPLINE_CTRL_POINT_SUFFICIENCY_ERROR_MESSAGE = (
+    "Number of B-Spline control points must be at least 1."
+)
+"""B-Spline model control point error message."""
+
+BSPLINE_ORDER_SUFFICIENCY_ERROR_MESSAGE = "B-Spline order must be at least 1."
+"""B-spline model order error message."""
+
 DEFAULT_TIMEPOINT_TOL = 1e-2
 """Time frame tolerance in seconds."""
 
@@ -202,10 +210,10 @@ class BSplinePETModel(BasePETModel):
         """
 
         if order < 1:
-            raise ValueError("B-Spline order must be at least 1.")
+            raise ValueError(BSPLINE_ORDER_SUFFICIENCY_ERROR_MESSAGE)
 
-        if n_ctrl is not None and n_ctrl < 1:
-            raise ValueError("Number of B-Spline control points must be at least 1.")
+        if n_ctrl < 1:
+            raise ValueError(BSPLINE_CTRL_POINT_SUFFICIENCY_ERROR_MESSAGE)
 
         super().__init__(dataset, **kwargs)
 

--- a/test/test_model_pet.py
+++ b/test/test_model_pet.py
@@ -31,6 +31,8 @@ from scipy.interpolate import BSpline
 from nifreeze.data.base import BaseDataset
 from nifreeze.data.pet import PET
 from nifreeze.model.pet import (
+    BSPLINE_CTRL_POINT_SUFFICIENCY_ERROR_MESSAGE,
+    BSPLINE_ORDER_SUFFICIENCY_ERROR_MESSAGE,
     MIN_TIMEPOINTS_ERROR_MSG,
     PET_MIDFRAME_ERROR_MSG,
     PET_OBJECT_ERROR_MSG,
@@ -113,6 +115,59 @@ def test_petmodel_init_dataset_error(setup_random_pet_data, monkeypatch):
 
     with pytest.raises(ValueError, match=PET_MIDFRAME_ERROR_MSG):
         BSplinePETModel(dataset=pet_obj_totald)  # type:ignore[arg-type]
+
+
+@pytest.mark.parametrize("order", [0, -1, -3, -10])
+def test_bspline_model_order_exception(setup_random_pet_data, order):
+    pet_dataobj, affine, brainmask_dataobj, _, midframe, total_duration = setup_random_pet_data
+
+    pet_obj = PET(
+        dataobj=pet_dataobj,
+        affine=affine,
+        brainmask=brainmask_dataobj,
+        midframe=midframe,
+        total_duration=total_duration,
+    )
+
+    with pytest.raises(ValueError, match=BSPLINE_ORDER_SUFFICIENCY_ERROR_MESSAGE):
+        BSplinePETModel(pet_obj, n_ctrl=3, order=order)
+
+
+@pytest.mark.parametrize("n_ctrl", [0, -1, -2, -10])
+def test_bspline_model_ctrl_point_exception(setup_random_pet_data, n_ctrl):
+    pet_dataobj, affine, brainmask_dataobj, _, midframe, total_duration = setup_random_pet_data
+
+    pet_obj = PET(
+        dataobj=pet_dataobj,
+        affine=affine,
+        brainmask=brainmask_dataobj,
+        midframe=midframe,
+        total_duration=total_duration,
+    )
+
+    with pytest.raises(ValueError, match=BSPLINE_CTRL_POINT_SUFFICIENCY_ERROR_MESSAGE):
+        BSplinePETModel(pet_obj, n_ctrl=n_ctrl, order=3)
+
+
+def test_bspline_model_knots_midframe_domain_coverage(setup_random_pet_data):
+    pet_dataobj, affine, brainmask_dataobj, _, midframe, total_duration = setup_random_pet_data
+
+    pet_obj = PET(
+        dataobj=pet_dataobj,
+        affine=affine,
+        brainmask=brainmask_dataobj,
+        midframe=midframe,
+        total_duration=total_duration,
+    )
+    model = BSplinePETModel(pet_obj, n_ctrl=4, order=3)
+
+    t = model._t
+    assert t.ndim == 1
+    assert t[0] <= np.floor(pet_obj.midframe[0])
+    assert t[-1] >= np.ceil(pet_obj.midframe[-1])
+    # open/clamped: first/last repeated order+1 times
+    assert np.all(t[: model._order + 1] == t[0])
+    assert np.all(t[-(model._order + 1) :] == t[-1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Check PET B-Spline model order and control point exceptions.

Do not check for `None` in the number of control points, as it is annotated as an integer.