### PR TITLE
DOC: Format propertly the `CITATION.cff` file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,24 +1,29 @@
 cff-version: 1.2.0
 message: "If you use this work, please cite it as below."
-title: "An open implementation of FSL's eddy with volume-to-volume artifact estimation for neuroimaging beyond diffusion MRI"
-authors:
-  - family-names: Legarreta
-    given-names: Jon Haitz
-  - family-names: Savary
-    given-names: Elodie
-  - family-names: Markiewicz
-    given-names: Christopher J.
-  - family-names: Rokem
-    given-names: Ariel
-  - family-names: Norgaard
-    given-names: Martin
-  - family-names: Esteban
-    given-names: Oscar
-date-released: 2025-05-10
-conference:
-  name: "34th Annual Conference & Exhibition of the International Society for Magnetic Resonance in Medicine (ISMRM)"
-  place: "Honolulu, HI USA"
-  date: 2025-05-10
-type: conference-paper
-abstract: "Program #3252"
-url: "https://osf.io/preprints/psyarxiv/gfny9_v2"
+references:
+- type: conference-paper
+    authors:
+      - family-names: Legarreta
+        given-names: Jon Haitz
+      - family-names: Savary
+        given-names: Elodie
+      - family-names: Markiewicz
+        given-names: Christopher J.
+      - family-names: Rokem
+        given-names: Ariel
+      - family-names: Norgaard
+        given-names: Martin
+      - family-names: Esteban
+        given-names: Oscar
+    title: "An open implementation of FSL's eddy with volume-to-volume artifact estimation for neuroimaging beyond diffusion MRI"
+    year: 2025
+    conference:
+      - name: "34th Annual Conference & Exhibition of the International Society for Magnetic Resonance in Medicine (ISMRM)"
+        city: Honolulu
+        region: HI
+        country: USA
+        date-start: 2025-05-10
+        date-end: 2025-05-15
+    doi: 10.58530/2025/3252
+    notes: "Program #3252"
+    url: "https://archive.ismrm.org/2025/3252.html"


### PR DESCRIPTION
Improve the formatting of the `CITATION.cff` file so that the current entry s clearly classified as a conference manuscript, and the date fileds can be parsed correctly for the type of venue.