### PR TITLE
MNT: Add citation file check CI workflow

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -1,0 +1,25 @@
+name: Check CITATION.cff
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - CITATION.cff
+  pull_request:
+    branches: ['main']
+    paths:
+      - CITATION.cff
+  workflow_dispatch:
+
+jobs:
+  validate-citation-cff:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate CITATION.cff
+        uses: dieghernan/cff-validator@v5

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@ and eddy-current-derived distortion estimation in dMRI.
    :target: https://github.com/nipreps/nifreeze/blob/main/LICENSE
    :alt: License
 
+.. image:: https://github.com/nipreps/nifreeze/actions/workflows/citation.yml/badge.svg
+   :target: https://github.com/nipreps/nifreeze/actions/workflows/citation.yml
+   :alt: Citation
+
 .. image:: https://img.shields.io/pypi/v/nifreeze.svg
    :target: https://pypi.python.org/pypi/nifreeze/
    :alt: Latest Version


### PR DESCRIPTION
Add citation file check CI workflow. Allows to detect a malformed CFF file.

Add the corresponding badge to the README file.