### PR TITLE
DOC: Fix `CITATION.cff` file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,29 +1,36 @@
 cff-version: 1.2.0
 message: "If you use this work, please cite it as below."
-references:
-- type: conference-paper
-    authors:
-      - family-names: Legarreta
-        given-names: Jon Haitz
-      - family-names: Savary
-        given-names: Elodie
-      - family-names: Markiewicz
-        given-names: Christopher J.
-      - family-names: Rokem
-        given-names: Ariel
-      - family-names: Norgaard
-        given-names: Martin
-      - family-names: Esteban
-        given-names: Oscar
-    title: "An open implementation of FSL's eddy with volume-to-volume artifact estimation for neuroimaging beyond diffusion MRI"
-    year: 2025
-    conference:
-      - name: "34th Annual Conference & Exhibition of the International Society for Magnetic Resonance in Medicine (ISMRM)"
-        city: Honolulu
-        region: HI
-        country: USA
-        date-start: 2025-05-10
-        date-end: 2025-05-15
-    doi: 10.58530/2025/3252
-    notes: "Program #3252"
-    url: "https://archive.ismrm.org/2025/3252.html"
+type: software
+title: "NiFreeze"
+authors:
+  - name: "The NiPreps Developers"
+repository-code: "https://github.com/nipreps/nifreeze"
+url: "https://www.nipreps.org/nifreeze/main/index.html"
+license: Apache-2.0
+preferred-citation:
+  type: conference-paper
+  authors:
+    - family-names: Legarreta
+      given-names: Jon Haitz
+    - family-names: Savary
+      given-names: Elodie
+    - family-names: Markiewicz
+      given-names: Christopher J.
+    - family-names: Rokem
+      given-names: Ariel
+    - family-names: Norgaard
+      given-names: Martin
+    - family-names: Esteban
+      given-names: Oscar
+  title: "An open implementation of FSL's eddy with volume-to-volume artifact estimation for neuroimaging beyond diffusion MRI"
+  year: 2025
+  conference:
+    name: "34th Annual Conference & Exhibition of the International Society for Magnetic Resonance in Medicine (ISMRM)"
+    city: Honolulu
+    region: HI
+    country: US
+    date-start: 2025-05-10
+    date-end: 2025-05-15
+  doi: 10.58530/2025/3252
+  notes: "Program #3252"
+  url: "https://archive.ismrm.org/2025/3252.html"


### PR DESCRIPTION
Fix `CITATION.cff` file.

Fixes:
```
Your CITATION.cfffile cannot be parsed. Make sure the formatting is
correct. Learn more about CITATION files.
```
visible on the GitHub repository when navigating to the file.

Ensure the file can be parsed running
```
pip install cffconvert
cffconvert --validate -i CITATION.cff
```

showing now:
```
Citation metadata are valid according to schema version 1.2.0.
```