### PR TITLE
DOC: Put citation check badge after PyPI badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,13 @@ and eddy-current-derived distortion estimation in dMRI.
    :target: https://github.com/nipreps/nifreeze/blob/main/LICENSE
    :alt: License
 
-.. image:: https://github.com/nipreps/nifreeze/actions/workflows/citation.yml/badge.svg
-   :target: https://github.com/nipreps/nifreeze/actions/workflows/citation.yml
-   :alt: Citation
-
 .. image:: https://img.shields.io/pypi/v/nifreeze.svg
    :target: https://pypi.python.org/pypi/nifreeze/
    :alt: Latest Version
+
+.. image:: https://github.com/nipreps/nifreeze/actions/workflows/citation.yml/badge.svg
+   :target: https://github.com/nipreps/nifreeze/actions/workflows/citation.yml
+   :alt: Citation
 
 .. image:: https://github.com/nipreps/nifreeze/actions/workflows/test.yml/badge.svg
    :target: https://github.com/nipreps/nifreeze/actions/workflows/test.yml


### PR DESCRIPTION
Put citation check badge after PyPI badge in README so that the action badges are all grouped.